### PR TITLE
[swayidle] increase screen timeout to 10 minutes

### DIFF
--- a/config/modules/ui/swayidle/default.nix
+++ b/config/modules/ui/swayidle/default.nix
@@ -1,13 +1,20 @@
-{pkgs, ...}: {
+{pkgs, ...}: let
+  # How long the session must be idle before the screen blanks (DPMS off).
+  screenTimeout = 10 * 60;
+
+  # The screen locks shortly after it blanks, rather than at the same instant.
+  lockDelayAfterScreenTimeout = 30;
+  lockTimeout = screenTimeout + lockDelayAfterScreenTimeout;
+in {
   primary-user.home-manager.services.swayidle = {
     enable = true;
     timeouts = [
       {
-        timeout = 330;
+        timeout = lockTimeout;
         command = "${pkgs.systemd}/bin/loginctl lock-session";
       }
       {
-        timeout = 300;
+        timeout = screenTimeout;
         command = "${pkgs.sway}/bin/swaymsg \"output * dpms off\"";
         resumeCommand = "${pkgs.sway}/bin/swaymsg \"output * dpms on\"";
       }


### PR DESCRIPTION
## What

Increase the idle screen timeout from 5 to 10 minutes.

In `config/modules/ui/swayidle/default.nix`:
- DPMS-off (screen blank) timeout: `300s` → `600s` (10 min)
- `lock-session` timeout: `330s` → `630s` (10.5 min)

The 30-second offset between the screen blanking and the session locking is preserved.

## Why

Per request — the screen was blanking too aggressively at 5 minutes.

## Notes

This is one of two PRs. The companion PR addresses the separate issue of DisplayLink monitors not coming back after the screen wakes from DPMS off.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F51fBDWcumRkZdnGtZ7uH2)_