### PR TITLE
[lyra] restart dlm on screen wake to fix DisplayLink resume

### DIFF
--- a/config/machines/lyra/default.nix
+++ b/config/machines/lyra/default.nix
@@ -27,6 +27,15 @@ in {
   };
   systemd.services.dlm.wantedBy = ["multi-user.target"];
 
+  # DisplayLink monitors on the dock do not wake back up when the screen
+  # returns from DPMS off (a regression that showed up with the kernel 6.18
+  # bump in nixos-26.05; the evdi outputs never re-initialize on resume).
+  # Restarting the DisplayLink manager re-creates the evdi outputs, which is
+  # what the manual `unplug/replug` or `systemctl restart dlm` workaround does
+  # by hand -- so do it automatically whenever the screen wakes.
+  screen-idle.dpmsResumeCommand = "/run/wrappers/bin/sudo ${pkgs.systemd}/bin/systemctl restart dlm.service";
+  primary-user.sudo-cmds = ["${pkgs.systemd}/bin/systemctl restart dlm.service"];
+
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
   hardware = {
     cpu.amd.updateMicrocode = true;

--- a/config/modules/ui/swayidle/default.nix
+++ b/config/modules/ui/swayidle/default.nix
@@ -1,12 +1,34 @@
-{pkgs, ...}: let
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
   # How long the session must be idle before the screen blanks (DPMS off).
   screenTimeout = 10 * 60;
 
   # The screen locks shortly after it blanks, rather than at the same instant.
   lockDelayAfterScreenTimeout = 30;
   lockTimeout = screenTimeout + lockDelayAfterScreenTimeout;
+
+  dpmsOn = "${pkgs.sway}/bin/swaymsg \"output * dpms on\"";
+  resumeCommand =
+    if config.screen-idle.dpmsResumeCommand == ""
+    then dpmsOn
+    else "${dpmsOn}; ${config.screen-idle.dpmsResumeCommand}";
 in {
-  primary-user.home-manager.services.swayidle = {
+  options.screen-idle.dpmsResumeCommand = lib.mkOption {
+    type = lib.types.str;
+    default = "";
+    description = ''
+      Extra shell command to run when the screen wakes from DPMS off, right
+      after outputs are re-enabled.  Intended for machines that need to nudge
+      an external display driver back to life on resume (e.g. restarting the
+      DisplayLink manager so evdi outputs re-initialize).
+    '';
+  };
+
+  config.primary-user.home-manager.services.swayidle = {
     enable = true;
     timeouts = [
       {
@@ -16,7 +38,7 @@ in {
       {
         timeout = screenTimeout;
         command = "${pkgs.sway}/bin/swaymsg \"output * dpms off\"";
-        resumeCommand = "${pkgs.sway}/bin/swaymsg \"output * dpms on\"";
+        inherit resumeCommand;
       }
     ];
     events = {


### PR DESCRIPTION
## The bug

On lyra, when docked, the DisplayLink monitors on the dock don't come back after the screen wakes from DPMS off (idle timeout). They stay dark until `dlm` is restarted or the dock is unplugged/replugged. The internal panel and any directly-attached outputs wake fine.

## Investigation

Your hunch about it being a kernel regression tied to the nixos-26.05 move looks right. Two things line up with that upgrade:

1. **Kernel 6.18 DPMS-wake regression.** nixos-26.05 ships kernel 6.18. There's a confirmed regression there where external displays fail to wake from DPMS off — reported on LKML ("External HDMI monitor fails to wake up from DPMS/consoleblank since kernel 6.18"), acknowledged by AMD's Alex Deucher and routed to the AMD DRM tracker. lyra is a Framework 13 **AMD**, so it's squarely in the affected set. Not present on 6.17.
2. **evdi/DisplayLink resume fragility on Wayland.** DisplayLink monitors aren't real amdgpu outputs — `dlm` renders them onto a virtual **evdi** DRM device and pushes pixels over USB. evdi has a long-standing weakness re-initializing its framebuffer/outputs after a `dpms off` → `dpms on` cycle on Wayland (evdi tears down the framebuffer on blank and doesn't cleanly bring it back). So even where the kernel wakes real connectors, the evdi ones stay dark.

Both of the manual fixes you've been using — `systemctl restart dlm` and unplug/replug — work because they force `dlm`/evdi to **re-create the outputs from scratch**, sidestepping the broken resume path.

A proper upstream fix belongs in the kernel (amdgpu DPMS regression) and/or evdi, and isn't something we can carry cleanly in the config. Pinning back to a 6.17 kernel would also dodge it but costs the newer kernel. So this PR ships the reliable, low-cost workaround instead.

## The fix

Automate the known-good manual workaround: restart `dlm` whenever the screen wakes.

- `config/modules/ui/swayidle/default.nix`: add a `screen-idle.dpmsResumeCommand` option that runs after outputs are re-enabled on DPMS resume (empty/no-op by default, so no behavior change on other machines).
- `config/machines/lyra/default.nix`: set that hook to `sudo systemctl restart dlm.service` and allow it passwordless via the existing `sudo-cmds` mechanism.

On wake, sway re-enables outputs and then `dlm` is restarted, which re-creates the evdi outputs — the DisplayLink monitors light back up on their own. When undocked it's a cheap `dlm` restart with nothing to re-create.

### Caveats
- Can't build/test this in the sandbox (no Nix); logic reviewed by hand. Worth confirming on lyra: after 10 min idle + wake, the dock monitors return without intervention.
- Restarting `dlm` re-creates the evdi connectors, so kanshi re-applies the matching profile on wake — same transient reshuffle you already see when restarting `dlm` by hand, just automatic now.

## Notes

Companion to the screen-timeout PR (#1). Independent of it — both branch from `main`; I'll rebase this once #1 lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F51fBDWcumRkZdnGtZ7uH2)_