### PR TITLE
[lyra] restart dlm on resume to fix DisplayLink after suspend

### DIFF
--- a/config/machines/lyra/default.nix
+++ b/config/machines/lyra/default.nix
@@ -27,6 +27,12 @@ in {
   };
   systemd.services.dlm.wantedBy = ["multi-user.target"];
 
+  # DisplayLink outputs on the dock do not survive a suspend/resume cycle:
+  # evdi/dlm does not re-establish them on wake, so the dock monitors stay
+  # dark until dlm is restarted (or the dock is replugged) by hand.  Restart
+  # dlm automatically on resume so the outputs come back.
+  powerManagement.resumeCommands = "${pkgs.systemd}/bin/systemctl restart dlm.service";
+
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
   hardware = {
     cpu.amd.updateMicrocode = true;


### PR DESCRIPTION
## The bug

On lyra, the DisplayLink monitors on the dock don't come back after a **suspend/resume** cycle. evdi/`dlm` doesn't re-establish the outputs on wake, so they stay dark until `dlm` is restarted or the dock is unplugged/replugged by hand.

This is specifically the *resume* path, not DPMS blanking — plain screen blank (screen off while the system stays awake) already recovers fine. That's why earlier DPMS-targeted attempts were aimed at the wrong moment.

## The fix

```nix
powerManagement.resumeCommands = "${pkgs.systemd}/bin/systemctl restart dlm.service";
```

`powerManagement.resumeCommands` runs as root via a systemd-sleep hook after the system resumes from suspend. Restarting `dlm` there re-creates the evdi outputs, so the dock monitors light back up automatically — the same thing the manual `systemctl restart dlm` / replug does by hand, wired to the actual wake event.

No swayidle, DPMS, or `sudo` involvement.

## Notes

- Can't build/test in the sandbox (no Nix); logic reviewed by hand. Worth confirming on lyra: suspend → resume → dock monitors return unaided.
- If it turns out a *lock without suspend* also drops the outputs, that's a separate hook we can add — but suspend/resume is the expected trigger.
- Supersedes the earlier DPMS-restart approach (closed #2) and the kernel-regression theory (that watch has been removed): the direct-monitor test showed only DisplayLink outputs are affected and only across resume, which points at evdi's suspend handling rather than the amdgpu kernel bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F51fBDWcumRkZdnGtZ7uH2)_