### PR TITLE
[home-assistant] Switch HA container to host networking for Govee LAN API

### DIFF
--- a/config/machines/crux/home-assistant.nix
+++ b/config/machines/crux/home-assistant.nix
@@ -6,7 +6,6 @@
 }: let
   passwords = pkgs.callPackage ../../../lib/passwords.nix {};
   network = pkgs.callPackage ../../../lib/network.nix {};
-  homeAssistantPort = "8123";
 in {
   deployment.keys = {
     "home-assistant.internal.prussin.net.crt" = {
@@ -25,6 +24,10 @@ in {
   networking.firewall.interfaces = {
     prussinnet.allowedTCPPorts = [80 443];
     podman0.allowedTCPPorts = [3000];
+    # Govee LAN API (used by the govee_light_local HA integration): multicast
+    # discovery/status on 4001, discovery replies on 4002, device commands on
+    # 4003. See https://www.home-assistant.io/integrations/govee_light_local/
+    "${config.interfaces.eth}".allowedUDPPorts = [4001 4002 4003];
   };
 
   users = {
@@ -67,10 +70,13 @@ in {
   virtualisation.oci-containers.containers.home-assistant = {
     image = "ghcr.io/home-assistant/home-assistant:stable";
     environment.TZ = "America/Los_Angeles";
-    ports = ["127.0.0.1:${homeAssistantPort}:${homeAssistantPort}"];
     extraOptions =
       [
         "--device=/dev/ttyACM0:/dev/ttyACM0"
+        # Host networking so the Govee LAN API's UDP multicast discovery
+        # (239.255.255.250:4001) and unicast replies (4002/4003) can reach
+        # the container; podman's default NAT bridge blocks multicast.
+        "--network=host"
       ]
       ++ (
         lib.mapAttrsToList


### PR DESCRIPTION
## Summary

The `govee_light_local` HA integration needs UDP multicast discovery (`239.255.255.250:4001`) plus unicast replies/commands (`4002`/`4003`) to reach the Govee H7026 strips. The HA container currently only publishes `127.0.0.1:8123` through podman's default NAT bridge, so that multicast/unicast traffic can't get in or out of the container's network namespace — this is why the integration hasn't been able to see the lights.

- Switch the `home-assistant` oci-container to `--network=host` (drops the `ports` publish, no longer needed) so it shares the host's network namespace and can join the multicast group / receive replies directly on `enp8s0`.
- Open UDP `4001`/`4002`/`4003` on the physical LAN interface (`config.interfaces.eth`) in the firewall.
- Removed the now-unused `homeAssistantPort` let-binding (was only used to build the removed `ports` mapping).

HA's web port (`8123`) is not explicitly opened in the firewall, so it stays unreachable from the LAN/WAN by the default-deny policy — external access still goes through the existing nginx TLS vhost on the WireGuard interface, unchanged by this PR.

## Test plan

- [ ] `colmena apply` (or equivalent) to crux and confirm `podman-home-assistant.service` restarts cleanly with `--network=host`
- [ ] In HA, add the **Govee Lights Local** integration and confirm the H7026 strips are discovered
- [ ] Confirm HA's web UI is still reachable via `https://home-assistant.internal.prussin.net` (over WireGuard) as before


---
_Generated by [Claude Code](https://claude.ai/code/session_01CYe7SKmAnMJt5ay5g4gtY2)_