### PR TITLE
[audio] Fix device priority, the speaker DSP chain, and its default volume

### DIFF
--- a/config/machines/lyra/default.nix
+++ b/config/machines/lyra/default.nix
@@ -24,6 +24,25 @@ in {
     getty.greetingLine = builtins.readFile ./greeting;
     fwupd.enable = true;
     xserver.videoDrivers = ["displaylink" "modesetting"];
+
+    # The audio enhancement filter chain above feeds the raw speaker sink and
+    # the two volumes compound, so the raw sink has to sit at 100% for the
+    # enhanced sink to reach full loudness.  `/` is tmpfs and we deliberately
+    # don't persist WirePlumber's state, so every boot would otherwise start it
+    # at WirePlumber's 0.064 default.  `apply-routes.lua` reads this per-device
+    # property only when there is no restored volume for the route, so adjusting
+    # the volume by hand still works for the rest of the session.
+    #
+    # This applies to every output route on the card, the 3.5mm jack included,
+    # so headphones plugged into the laptop itself also start at full volume.
+    pipewire.wireplumber.extraConfig."51-speaker-default-volume" = {
+      "monitor.alsa.rules" = [
+        {
+          matches = [{"device.name" = "alsa_card.pci-0000_c1_00.6";}];
+          actions.update-props."device.routes.default-sink-volume" = 1.0;
+        }
+      ];
+    };
   };
   systemd.services.dlm.wantedBy = ["multi-user.target"];
 
@@ -42,6 +61,14 @@ in {
       laptop13.audioEnhancement = {
         enable = true;
         hideRawDevice = false;
+
+        # WirePlumber's `node.software-dsp` rule builds the filter chain by
+        # matching this string against `node.name` exactly, so a wrong value
+        # means the enhanced sink is never created and the option silently does
+        # nothing.  nixos-hardware defaults this to the UCM name
+        # (`alsa_output.pci-0000_c1_00.6.HiFi__Speaker__sink`), but the speaker
+        # card comes up on the generic ALSA card profile here, not under UCM.
+        rawDeviceName = "alsa_output.pci-0000_c1_00.6.analog-stereo";
       };
     };
   };

--- a/config/modules/system/devices/audio/default.nix
+++ b/config/modules/system/devices/audio/default.nix
@@ -1,4 +1,48 @@
-_: {
+_: let
+  # WirePlumber picks the default sink by taking the node with the highest
+  # `priority.session` (see its `find-best-default-node.lua`), and its defaults
+  # get that wrong for us in two ways:
+  #
+  #   - The ALSA monitor scores every analog USB sink identically: 1000 for
+  #     hardware device 0, +9 for the analog profile, and +100 for sitting on
+  #     the USB bus.  So the Plugable dock's analog jack ties with real USB
+  #     speakers at 1109 and wins the tie on enumeration order, even though
+  #     nothing is ever plugged into the jack.
+  #   - The bluez monitor sets no priority at all, so Bluetooth sinks fall back
+  #     to 0 and can never win against a wired sink.
+  #
+  # Give each class its own band instead.  Only `priority.session` is
+  # overridden: `priority.driver` decides which node drives the graph clock, and
+  # Bluetooth in particular makes a poor driver.
+  #
+  # The bands are chosen to sit around the priorities we leave alone, which on
+  # lyra are 1009 for the internal speakers and ~584 for the Radeon HDMI output.
+  bluetoothSinks = [{"node.name" = "~bluez_output..*";}];
+
+  usbSinks = [{"node.name" = "~alsa_output.usb-.*";}];
+
+  # The analog jack on the Plugable UD-6950PDZ dock is a USB audio device, so
+  # the rule above would otherwise promote it alongside real USB speakers.
+  # Nothing is ever plugged into that jack, so sort it below everything else,
+  # including the internal speakers; it can still be selected by hand.  Its
+  # capture side (an IEC958 input) gets the same treatment.
+  #
+  # The node name is built from the USB vendor and product strings, which is
+  # brittle enough to be worth matching a few ways: `wpctl inspect` on the sink
+  # shows what `node.name` and `node.description` actually came out as.
+  dockNodes = [
+    {"node.name" = "~alsa_output.usb-.*UD-6950.*";}
+    {"node.name" = "~alsa_input.usb-.*UD-6950.*";}
+    {"node.name" = "~alsa_output.usb-DisplayLink.*";}
+    {"node.name" = "~alsa_input.usb-DisplayLink.*";}
+    {"node.description" = "~Plugable UD-6950.*";}
+  ];
+
+  mkPriorityRule = matches: priority: {
+    inherit matches;
+    actions.update-props."priority.session" = priority;
+  };
+in {
   security.rtkit.enable = true;
 
   services.pipewire = {
@@ -6,5 +50,15 @@ _: {
     alsa.enable = true;
     pulse.enable = true;
     jack.enable = true;
+
+    # Rules apply in order and later ones win, so the dock rule has to follow
+    # the general USB rule that it narrows.
+    wireplumber.extraConfig."50-audio-device-priorities" = {
+      "monitor.alsa.rules" = [
+        (mkPriorityRule usbSinks 2000)
+        (mkPriorityRule dockNodes 500)
+      ];
+      "monitor.bluez.rules" = [(mkPriorityRule bluetoothSinks 3000)];
+    };
   };
 }

--- a/config/modules/system/devices/audio/default.nix
+++ b/config/modules/system/devices/audio/default.nix
@@ -16,7 +16,9 @@ _: let
   # Bluetooth in particular makes a poor driver.
   #
   # The bands are chosen to sit around the priorities we leave alone, which on
-  # lyra are 1009 for the internal speakers and ~584 for the Radeon HDMI output.
+  # lyra are 1500 for the enhanced internal speaker sink from
+  # `hardware.framework.laptop13.audioEnhancement` (1009 for the raw sink behind
+  # it) and ~584 for the Radeon HDMI output.
   bluetoothSinks = [{"node.name" = "~bluez_output..*";}];
 
   usbSinks = [{"node.name" = "~alsa_output.usb-.*";}];


### PR DESCRIPTION
Three related audio fixes on lyra.

## 1. Default sink priority

The default sink ends up on the Plugable UD-6950PDZ dock's analog jack even with nothing plugged into it, and Bluetooth headphones never take over.

WirePlumber picks the default sink by taking the node with the highest `priority.session` (`find-best-default-node.lua`), and the upstream scoring produces this:

| sink | `priority.session` | where from |
| --- | --- | --- |
| `Plugable UD-6950PDZ Analog Stereo` | 1109 | ALSA monitor: 1000 (hw device 0) + 9 (analog profile) + 100 (USB bus) |
| `USB2.0 Device Analog Stereo` (Sanyun SW208) | 1109 | same formula, identical score |
| `Ryzen HD Audio Controller Analog Stereo` (internal) | 1009 | same, no USB bonus |
| `Radeon ... Digital Stereo (HDMI 3)` | ~584 | non-device-0, no profile bonus |
| `Coding Headphones` (Bluetooth) | 0 | the bluez monitor sets no priority at all |

The dock and the USB speakers tie exactly, and the tie is broken by enumeration order — which is why the dock wins (`wpctl status` confirms it as the current default). Bluetooth has no priority set anywhere — WirePlumber 0.4's `bluez.lua` used to assign 1010, 0.5 dropped that and nothing replaced it — so it falls back to 0 and can never beat a wired sink.

A WirePlumber drop-in overrides `priority.session` so each class gets its own band:

```
Bluetooth (3000) > USB speakers (2000) > internal speakers (1500) > dock analog jack (500)
```

- Only `priority.session` is overridden. `priority.driver` selects which node drives the graph clock, and Bluetooth makes a poor driver, so it is left alone.
- The dock sorts below everything, since nothing is ever plugged into its jack. It can still be selected by hand. Its capture side (the IEC958 input) is demoted the same way, which leaves the BRIO as the default source.
- Only Bluetooth *sinks* are promoted — `bluez_input` is deliberately left alone so connecting headphones doesn't drag the default source onto the headset mic and force the HFP profile.
- 1500 is the enhanced internal speaker sink from fix 2 below; the raw sink behind it stays at 1009.

## 2. The speaker DSP filter chain never ran

`hardware.framework.laptop13.audioEnhancement.enable = true` was set, but `wpctl status` showed no `audio_effect.laptop-convolver` sink at all — the option was silently doing nothing.

WirePlumber's `node/software-dsp.lua` creates the filter chain from a `node.software-dsp.rules` entry that matches `rawDeviceName` against `node.name` **exactly**, on `node-added`. No match means no filter node is ever created, and nothing is logged above debug level. nixos-hardware's AMD AI 300 module defaults `rawDeviceName` to the UCM name:

```nix
lib.mkDefault "alsa_output.pci-0000_c1_00.6.HiFi__Speaker__sink"
```

but the speaker card comes up on the generic ALSA card profile here, not under UCM — hence the `Ryzen HD Audio Controller Analog Stereo` description in `wpctl status`. Set `rawDeviceName` to the profile name that actually exists.

## 3. Raw speaker sink defaults to 100%

The filter chain's volume compounds with the raw speaker sink's, so nixos-hardware's option documentation tells you to put the raw device at 100% before enabling. `/` is tmpfs here and WirePlumber state is deliberately not persisted, so the raw sink came back at WirePlumber's `device.routes.default-sink-volume` default of 0.064 (the `vol: 0.40` cubic value on every sink in `wpctl status`) on each boot.

`apply-routes.lua` consults a per-device property override before falling back to that global setting:

```lua
props.channelVolumes = props.channelVolumes or {
  (is_input and tonumber(device.properties["device.routes.default-source-volume"]))
  or tonumber(device.properties["device.routes.default-sink-volume"])
  or (is_input and Settings.get_float ("device.routes.default-source-volume"))
  or Settings.get_float ("device.routes.default-sink-volume")
}
```

Setting it via `monitor.alsa.rules` on the speaker card gives the wanted behaviour: full volume by default every boot, still adjustable by hand for the rest of the session, and no change to any other device.

**Caveat worth a look:** the property is per-device, not per-route, so every output route on that card gets it — headphones plugged into the laptop's own 3.5mm jack will also start at full volume. There's no per-route override in WirePlumber. Say the word and I'll drop this part or find another angle.

## Testing

Not deployed — no access to lyra or to `nix` in this environment, so this is evaluated by inspection only, against a `wpctl status` dump from the machine and the WirePlumber/nixos-hardware sources.

Two strings are matched exactly and are worth confirming with `pactl list sinks short` / `pactl list cards short` after deploying:

- `alsa_output.pci-0000_c1_00.6.analog-stereo` — the PCI address comes from nixos-hardware's own default for this board, only the profile suffix is changed.
- `alsa_card.pci-0000_c1_00.6` — same card, device-level name.

The dock is matched more loosely (`node.name` containing `UD-6950`, the `usb-DisplayLink` prefix, or a `Plugable UD-6950` description), so it should survive either naming.

Expected after `colmena apply`: a `Framework Speakers` sink at 100%, Bluetooth default when connected, the Sanyun speakers when not, and the dock never picked automatically.