### PR TITLE
[backlight] Adjust the screen brightness to the ambient light level

### DIFF
--- a/config/machines/lyra/default.nix
+++ b/config/machines/lyra/default.nix
@@ -118,6 +118,7 @@ in {
         "tank/persisted-state/root-containers".mountpoint = "/var/lib/containers";
         "tank/persisted-state/syncthing".mountpoint = "/home/${config.primary-user.name}/.cache/syncthing";
         "tank/persisted-state/syncthing-config".mountpoint = "/home/${config.primary-user.name}/.config/syncthing";
+        "tank/persisted-state/wluma".mountpoint = "/home/${config.primary-user.name}/.local/share/wluma";
         "tank/persisted-state/secrets" = {
           mountpoint = "/secrets";
           neededForBoot = true;

--- a/config/modules/system/devices/backlight/default.nix
+++ b/config/modules/system/devices/backlight/default.nix
@@ -1,3 +1,122 @@
-_: {
+{pkgs, ...}: let
+  inherit (pkgs) coreutils;
+
+  # These are wluma's own default thresholds: raw ambient light readings (in
+  # lux) are bucketed into these named profiles, and wluma learns a separate
+  # brightness preference for each one.  We have to ship a config file anyway
+  # to point wluma at the right backlight, so they're spelled out here rather
+  # than left implicit.
+  alsConfig = pkgs.writeText "wluma-als.toml" ''
+    [als.iio]
+    path = "/sys/bus/iio/devices"
+    thresholds = { 0 = "night", 20 = "dark", 80 = "dim", 250 = "normal", 500 = "bright", 800 = "outdoors" }
+  '';
+
+  # wluma wants the sysfs directory of the panel's backlight, which is named
+  # after whichever driver registered it (`amdgpu_bl1`, `intel_backlight`,
+  # ...) and so isn't a path a profile shared by every laptop can hardcode.
+  # Pick out the backlight hanging off the internal panel's DRM connector
+  # instead, and name the output after that connector, so the learned data
+  # survives the backlight device being renumbered.
+  writeConfig = pkgs.writeShellScript "wluma-write-config" ''
+    panel=
+    output=
+
+    for backlight in /sys/class/backlight/*
+    do
+      [ -e "$backlight/device" ] || continue
+      connector=$(${coreutils}/bin/basename "$(${coreutils}/bin/readlink -f "$backlight/device")")
+      case "$connector" in
+        *-eDP-*)
+          panel=$backlight
+          output=''${connector#*-}
+          break
+          ;;
+      esac
+    done
+
+    # Not every driver registers its backlight against a DRM connector
+    # (`acpi_video0` hangs off the ACPI device, and older drivers off the pci
+    # device), so where there's only one backlight to begin with, take it.
+    if [ -z "$panel" ]
+    then
+      set -- /sys/class/backlight/*
+      if [ $# -eq 1 ] && [ -d "$1" ]
+      then
+        panel=$1
+        output=$(${coreutils}/bin/basename "$1")
+      fi
+    fi
+
+    if [ -z "$panel" ]
+    then
+      echo "Found no internal panel backlight under /sys/class/backlight!" >&2
+      exit 1
+    fi
+
+    {
+      ${coreutils}/bin/cat ${alsConfig}
+
+      # Ambient light alone decides the brightness.  wluma can also factor in
+      # how bright the screen contents are, but that isn't what macos-style
+      # auto-brightness does, and it means capturing the screen several times
+      # a second.
+      ${coreutils}/bin/printf \
+        '\n[[output.backlight]]\nname = "%s"\npath = "%s"\ncapturer = "none"\n' \
+        "$output" "$panel"
+    } > "$RUNTIME_DIRECTORY/config.toml"
+  '';
+in {
   primary-user.extraGroups = ["video"];
+
+  # brightnessctl ships udev rules granting the `video` group write access to
+  # /sys/class/backlight/*/brightness.  wluma works without them by going
+  # through logind over dbus, but only direct writes are quick enough for it
+  # to ramp the backlight smoothly.  The same rules also hand the `input`
+  # group write access to /sys/class/leds/*/brightness, which nothing here
+  # needs but which comes along with them.
+  services.udev.packages = [pkgs.brightnessctl];
+
+  # wluma doesn't do anything until it has been taught: adjust the brightness
+  # by hand a few times in different lighting and it starts reproducing those
+  # choices on its own.  That training lives in ~/.local/share/wluma, which
+  # has to be persisted on machines with an ephemeral root.
+  primary-user.home-manager.systemd.user.services.wluma = {
+    Unit = {
+      Description = "Adjust the backlight to the ambient light level";
+      PartOf = ["graphical-session.target"];
+      After = ["graphical-session.target"];
+
+      # wluma panics rather than degrades when the sensor isn't there, and
+      # the script above bails when the panel isn't either, but the sensor
+      # may genuinely not be bound yet at login, so retries are worth having.
+      # The default limit of five starts per ten seconds can't catch a five
+      # second restart delay, so widen the window enough that a sensor that
+      # never turns up leaves the unit failed instead of backtracing into the
+      # journal every five seconds forever.  Only failures to start are
+      # bounded this way: wluma also panics when it can't save what it has
+      # learned, and those are as far apart as the brightness keypresses that
+      # provoke them.  A spent burst refuses every start for the rest of the
+      # window, so recovering inside one takes a `reset-failed`.
+      StartLimitIntervalSec = 300;
+      StartLimitBurst = 5;
+    };
+
+    Service = {
+      Type = "simple";
+
+      # wluma only reads its config from $XDG_CONFIG_HOME/wluma/config.toml,
+      # and we generate that config at startup, so point it at the unit's
+      # runtime directory for the duration.
+      RuntimeDirectory = "wluma";
+      Environment = ["XDG_CONFIG_HOME=%t"];
+
+      ExecStartPre = "${writeConfig}";
+      ExecStart = "${pkgs.wluma}/bin/wluma";
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+
+    Install.WantedBy = ["graphical-session.target"];
+  };
 }


### PR DESCRIPTION
Lyra has an ambient light sensor (nixos-hardware already enables `hardware.sensor.iio` for the Framework 13), but nothing under sway reads it, so the backlight only moves when the brightness keys are pressed.

## What this does

Runs [wluma](https://github.com/maximbaz/wluma) as a user service on the laptop profile. Like macos, it doesn't impose a fixed curve — it watches manual brightness changes and learns the preferred level per lighting condition.

- **Nothing happens until it's trained.** Adjust brightness by hand a few times in different light; from then on it reproduces those choices and keeps learning from further adjustments.
- **Ambient light only** (`capturer = "none"`). wluma can also factor in how bright the screen contents are, but that isn't macos-style auto-brightness and it means capturing the screen several times a second.
- **Backlight device found at startup.** The sysfs directory is named after whichever driver registered it (`amdgpu_bl1`, `intel_backlight`, …), so the config is generated from whichever backlight hangs off the internal panel's DRM connector, falling back to the sole backlight when nothing is connector-parented. The wluma output is named after that connector (`eDP-1`) so learned data survives the backlight device being renumbered.
- **brightnessctl's udev rules** are pulled in so the `video` group can write `/sys/class/backlight/*/brightness` directly. wluma works without them via logind over dbus, but only direct writes are fast enough for smooth ramps. This also speeds up the existing brightness keybindings. (Those rules additionally make `/sys/class/leds/*/brightness` writable by group `input` — nothing here needs that, but it comes along with them.)
- **Learned data is persisted.** Lyra's root is a tmpfs, so `~/.local/share/wluma` gets its own dataset — otherwise wluma would start over from nothing on every boot.
- **Restarts are bounded.** wluma panics rather than degrades on a missing sensor, so `StartLimitIntervalSec`/`StartLimitBurst` let it retry through a sensor that isn't bound yet at login and then stay failed, instead of backtracing into the journal every 5s forever.

## ⚠️ Before deploying

The dataset has to exist *and be owned by the user* first. `install-user-mountpoints` chowns before `local-fs-pre.target`, so it only touches the tmpfs mountpoint — never the dataset's own root inode, which is `root:root` at creation. wluma swallows the resulting read error at load and only panics on the first *save*, i.e. the first time it learns something.

```
zfs create tank/persisted-state/wluma
chown cprussin:users /home/cprussin/.local/share/wluma
```

## ⚠️ Worth checking once, after deploy

**Is the sensor reporting lux?** The default thresholds assume so. wluma computes `(in_illuminance_raw + in_illuminance_offset) * in_illuminance_scale`, defaulting scale to 1.0 when absent — so if the Framework's ALS exposes unscaled HID counts, every reading lands in one bucket and wluma quietly degenerates into a single brightness level (which looks like "it never learned anything" rather than a failure).

```
cat /sys/bus/iio/devices/iio:device*/in_illuminance_*
```

in a dark room and again in daylight; retune the buckets if the range doesn't look like lux.

**If it won't start,** note the widened start limit cuts both ways: once the burst is spent, every start for the rest of the 300s window is refused, including logging back in and a manual start. After fixing whatever was wrong:

```
systemctl --user reset-failed wluma && systemctl --user start wluma
```

**Two silent failure modes** worth knowing the shape of: if the chosen backlight can't be opened, wluma logs a single `Skipping '…' as it might be disconnected` and runs on with no outputs — `active`, and completely inert. And if it can't find its config it silently falls back to its built-in defaults, which target `intel_backlight` with `capturer = "wayland"`. Either one looks like "nothing is happening" rather than an error.

## Verification

Nix isn't deployable from here, but everything checkable was checked:

- `alejandra --check .`, `statix check .`, `deadnix .` all clean.
- Built the generated config script and ran it against fake `/sys/class/backlight` trees: picks `amdgpu_bl1` over an `acpi_video0` decoy and names the output `eDP-1`; falls back to the single backlight when none is connector-parented; exits nonzero with a clear message when there are none or when it's ambiguous.
- Ran `wluma` itself against a simulated sysfs (iio device named `als` reporting 150 lux, a writable fake backlight) with the generated config: it bucketed to the `dim` profile, chose direct sysfs writes, and wrote `eDP-1.yaml` into its data dir.
- Confirmed the Framework's sensor path lines up: it comes up through `hid-sensor-hub`, and `hid-sensor-als` names the IIO device `als`, the first entry in wluma's accepted-name list. `als_read_raw()` takes no direct-mode claim, so iio-sensor-proxy holding the buffer doesn't block wluma's sysfs reads.

## Not included

Keyboard backlight. Macos does that too, but I couldn't verify the Framework LED path from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133MKDpdCQBHxphRLfCXXwg