### PR TITLE
[backup] Replace the scrub watch with a redrawing progress loop

### DIFF
--- a/config/machines/crux/backup.nix
+++ b/config/machines/crux/backup.nix
@@ -53,11 +53,33 @@
 
     echo
     echo -e "\e[1;37mScrubbing tank-backup...\e[0m"
-    watch -n1 zpool status tank-backup &
-    PID=$!
-    zpool scrub -w tank-backup
-    kill -INT $PID
-    zpool status tank-backup
+    zpool scrub tank-backup
+    exec 3>&1
+    DRAWN=0
+    clearProgress() {
+      if [ -t 1 ] && [ "$DRAWN" -gt 0 ]
+      then
+        printf '\033[%dA\033[J' "$DRAWN" || true
+        DRAWN=0
+      fi
+    }
+    while true
+    do
+      NEXT=$(zpool status tank-backup 2>&1) || { clearProgress; echo "$NEXT" >&2; break; }
+      STATUS=$NEXT
+      clearProgress
+      echo "$STATUS" | grep -q 'scrub in progress' || break
+      if [ -t 1 ]
+      then
+        WIDTH=$(tput cols <&3 2>/dev/null || echo 80)
+        PROGRESS=$(echo "$STATUS" | sed -n '/scan:/,/^config:/{/^config:/!p}' | expand | cut -c "1-$WIDTH")
+        echo "$PROGRESS"
+        DRAWN=$(echo "$PROGRESS" | wc -l)
+      fi
+      sleep 1
+    done
+    exec 3>&-
+    echo "$STATUS"
 
     echo
     echo -e "\e[1;37mCleaning up...\e[0m"


### PR DESCRIPTION
`run-backup` stalled at `Scrubbing tank-backup...` printing `watch: getchar(): Success`.

**Cause:** procps-ng's `watch` reads stdin for interactive keys; backgrounded (`watch -n1 ... &`) its `getchar()` fails immediately, so it exits and nothing is ever shown. `zpool scrub -w` then ran to completion with no output.

**Fix:** drop `watch` and poll `zpool status` in the foreground:

- On a terminal: print the `scan:` block, then `ESC[<n>A ESC[J` back over it each second so it refreshes in place. Lines are `expand`ed and truncated to the terminal width first, so one logical line is always one row and the cursor-up count stays right on a narrow window. Width is read through a saved copy of stdout (`exec 3>&1`; `tput cols <&3`), since `tput` inside `$( )` otherwise measures stderr or stdin.
- Not a terminal: no progress output at all — the final status is the only thing printed, instead of a near-identical block every second for hours.
- A failing `zpool status` breaks the loop rather than tripping `set -e`, so the cleanup below (export, lock, snapshot destroy) still runs.
- On completion the last progress block is cleared and the full status (config + errors) prints once.

Verified against a stubbed `zpool`, rendered through pyte in a 45x30 pty: in-place redraw with no residue, earlier output preserved, correct width with stdin redirected from `/dev/null`, only the final status when piped, and cleanup reached with exit 0 when `zpool status` fails.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDqamJFvqXMeXv3TmDqBev)_