### PR TITLE
[flake] Only expose the isos on systems they're built for

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -148,9 +148,16 @@
             ];
             config = {};
           };
+
+          # The isos are only built for the systems in `supportedSystems`
+          # above, so drop the ones this system has no build for rather than
+          # leaving `packages` with attributes that throw on access.
+          isoPackages =
+            builtins.mapAttrs (_: value: value."${system}")
+            (nixpkgs.lib.filterAttrs (_: builtins.hasAttr system) isos);
         in {
           packages =
-            (builtins.mapAttrs (_: value: value."${system}") isos)
+            isoPackages
             // {
               inherit (pkgs) iot-devices;
             };


### PR DESCRIPTION
Fixes `nix flake show --all-systems` and `nix flake check --all-systems`, which throw today.

## The bug

`mkMinimalIso` passes `supportedSystems = ["x86_64-linux"]` to `release.nix`, so each entry in `isos` is an attrset with exactly one key:

```nix
isos.installer = { x86_64-linux = <drv>; };
```

`packages` then selected off it unconditionally:

```nix
packages = (builtins.mapAttrs (_: value: value."${system}") isos) // { ... };
```

`eachDefaultSystem` also runs for `aarch64-linux`, `x86_64-darwin` and `aarch64-darwin`, where that key doesn't exist — so `packages.aarch64-linux.installer` throws when forced.

Scope, measured rather than assumed:

| command | before |
| --- | --- |
| `nix flake show` | passes — prints `omitted (use '--all-systems' to show)`, never forces the other systems |
| `nix flake check` | passes — warns about omitted incompatible systems |
| `nix flake show --all-systems` | `error: attribute 'aarch64-darwin' missing` |
| `nix flake check --all-systems` | `error: attribute 'aarch64-linux' missing` |

`mapAttrs` is lazy in its values, which is why the plain forms were fine. `nix build .#installer` was never affected either — it only resolves the current system.

## The fix

Filter to the systems each iso actually has a build for, derived from the attrs themselves rather than by re-hardcoding `x86_64-linux`:

```nix
isoPackages =
  builtins.mapAttrs (_: value: value."${system}")
  (nixpkgs.lib.filterAttrs (_: builtins.hasAttr system) isos);
```

`packages.x86_64-linux` is unchanged — `installer`, `gpg-offline`, `iot-devices`. Other systems now expose just `iot-devices` instead of two attributes that throw.

## Not covered by this change

`devShells.default` is still evaluated per system and pulls `colmena` and `vulnix` (via `cli`). If those are Linux-only in `meta.platforms`, `nix flake check --all-systems` may still fail further along on darwin. Unverified — flagging it so `--all-systems` isn't assumed green on the strength of this PR alone.

Spotted while adding CI in #13; it's why that workflow builds specific attributes instead of running `nix flake check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVNS9yNwURwF5tW2whza94