### PR TITLE
[ci] Check the flake on every system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,30 @@ jobs:
         if: ${{ !cancelled() }}
         run: nix develop --command cli test format
 
+  # `--all-systems` is the point: without it both commands only look at the
+  # runner's own system, which is the one that always worked.  It was the other
+  # three that carried outputs which threw when forced.
+  #
+  # `check` subsumes `show` for coverage -- it forces each `packages.<system>.*`
+  # to its `drvPath`, where `show` forces only far enough to print a name -- so
+  # the `show` step is here for its readable tree, not to catch anything `check`
+  # would miss.
+  flake-check:
+    name: flake check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+      - uses: cachix/install-nix-action@v31
+      - name: nix flake show
+        run: nix flake show --all-systems
+      - name: nix flake check
+        if: ${{ !cancelled() }}
+        # No `checks` outputs today, so this only evaluates.  Keep the build
+        # logs on rather than passing `--no-build`: if `checks` are ever added,
+        # they should actually run here, and say why when they fail.
+        run: nix flake check --print-build-logs --all-systems
+
   build:
     name: build ${{ matrix.package }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a `flake-check` job running `nix flake show --all-systems` and `nix flake check --all-systems`.

## Why

This is the gap that let #14's bug sit unnoticed: `packages.<system>` carried iso attributes that threw when forced, on the three systems with no iso build. Nothing in CI would have caught it — and the `eval-isos` job that existed at the time couldn't have, since it pinned `x86_64-linux`, the one system that worked.

`--all-systems` is the load-bearing part. Without it both commands only look at the runner's own system.

Cheap job: `nix flake check` builds `checks` outputs (there are none here) and only evaluates everything else, so this is an eval-only pass.

## This may go red, and that would be the finding

The review on #14 flagged, unverified, that `devShells.default` is evaluated per system and pulls `colmena` and `vulnix` (via `cli`), plus `cli` reaches `esphome` through `iot.nix`. If any of those are Linux-only in `meta.platforms`, `checkMeta` throws on `x86_64-darwin` / `aarch64-darwin` and this job fails.

I haven't been able to run nix in this session, so this PR's own CI is the first real test. If it's red on darwin that's a genuine result, not a broken job: it means `flake-utils.lib.eachDefaultSystem` is advertising four systems this flake only supports one of. The fix would be narrowing the systems list rather than deleting the check — I'd raise it rather than merge around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVNS9yNwURwF5tW2whza94

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVNS9yNwURwF5tW2whza94)_