### PR TITLE
[launcher] Add ChatGPT and Claude desktop app launchers

### DIFF
--- a/config/machines/lyra/default.nix
+++ b/config/machines/lyra/default.nix
@@ -108,7 +108,9 @@ in {
         "tank/persisted-state/alsa".mountpoint = "/var/lib/alsa";
         "tank/persisted-state/argo".mountpoint = "/home/${config.primary-user.name}/.config/argo";
         "tank/persisted-state/bluetooth".mountpoint = "/var/lib/bluetooth";
+        "tank/persisted-state/chatgpt".mountpoint = "/home/${config.primary-user.name}/.config/chatgpt";
         "tank/persisted-state/chromium".mountpoint = "/home/${config.primary-user.name}/.config/chromium";
+        "tank/persisted-state/claude".mountpoint = "/home/${config.primary-user.name}/.config/claude";
         "tank/persisted-state/containers".mountpoint = "/home/${config.primary-user.name}/.local/share/containers";
         "tank/persisted-state/direnv-allow".mountpoint = "/home/${config.primary-user.name}/.local/share/direnv/allow";
         "tank/persisted-state/discord".mountpoint = "/home/${config.primary-user.name}/.config/discord";

--- a/config/modules/ui/launcher/default.nix
+++ b/config/modules/ui/launcher/default.nix
@@ -6,6 +6,7 @@
 }: let
   mkWebApp = pkgs.callPackage ./utils/mkWebApp.nix {};
   mkGoogleApp = pkgs.callPackage ./utils/mkGoogleApp.nix {};
+  mkDesktopApp = pkgs.callPackage ./utils/mkDesktopApp.nix {};
   mkTerminalApp' = pkgs.callPackage ./utils/mkTerminalApp.nix {inherit config;};
   mkTerminalApp = name: mkTerminalApp' name name;
   mkModal = pkgs.callPackage ./utils/mkModal.nix {inherit config;};
@@ -47,8 +48,10 @@ in {
           brightness = pkgs.callPackage ./apps/brightness.nix {};
           btop = mkTerminalApp "btop" "${pkgs.btop}/bin/btop";
           calendar = mkGoogleApp "calendar" "https://calendar.google.com";
+          chatgpt = mkDesktopApp "chatgpt" "https://chatgpt.com";
           chrome = pkgs.writeShellScript "chrome" "${pkgs.launcher}/bin/browse --browser chrome $*";
           chromium = pkgs.writeShellScript "chromium" "${pkgs.launcher}/bin/browse --browser chromium $*";
+          claude = mkDesktopApp "claude" "https://claude.ai";
           credit-cards = mkWebApp "credit-cards" "https://docs.google.com/spreadsheets/d/1Y8xind-5nMe9bezMFmk__CQdkSBd7FPupt1NkdKDLUE?authuser=connor@prussin.net";
           crux = mkTerminalApp "crux" "${pkgs.openssh}/bin/ssh -t crux load-session";
           cups = mkWebApp "cups" "http://localhost:631";

--- a/config/modules/ui/launcher/utils/mkDesktopApp.nix
+++ b/config/modules/ui/launcher/utils/mkDesktopApp.nix
@@ -1,0 +1,10 @@
+{
+  writeShellScript,
+  brave,
+}: name: url:
+writeShellScript name ''
+  exec ${brave}/bin/brave \
+    --app=${url} \
+    --user-data-dir="$HOME/.config/${name}" \
+    >/dev/null 2>&1
+''


### PR DESCRIPTION
Adds `chatgpt` and `claude` launcher apps, plus the lyra datasets that keep their local data.

- **No Linux desktop builds exist** for either: nixpkgs' `chatgpt` is the macOS `.dmg` (`platforms = darwin`) and there is no `claude-desktop` package in 26.05 or unstable. So both run as Brave `--app=` windows — chromeless, one window per site.
- New `utils/mkDesktopApp.nix`, alongside `mkWebApp`/`mkGoogleApp`, differing in that it gives each app its own `--user-data-dir` (`~/.config/<name>`) instead of opening in the main Brave profile.
- `tank/persisted-state/chatgpt` and `tank/persisted-state/claude` on lyra, so those profiles survive the tmpfs root.
- No sway change needed — the existing `^brave-.*` app_id rule matches these windows.

Not verified with `nix flake check` / `alejandra` (no nix in this environment); leaving that to CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_013VHH9pj1eDhtmmfNwE4ZnY)_