### PR TITLE
[launcher] Add the Claude and ChatGPT desktop apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
       fail-fast: false
       matrix:
         package:
+          - claude-desktop
           - dircolors-solarized
           - emojione-png
           - mako

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
       fail-fast: false
       matrix:
         package:
+          - chatgpt-desktop
           - claude-desktop
           - dircolors-solarized
           - emojione-png

--- a/config/machines/lyra/default.nix
+++ b/config/machines/lyra/default.nix
@@ -108,9 +108,11 @@ in {
         "tank/persisted-state/alsa".mountpoint = "/var/lib/alsa";
         "tank/persisted-state/argo".mountpoint = "/home/${config.primary-user.name}/.config/argo";
         "tank/persisted-state/bluetooth".mountpoint = "/var/lib/bluetooth";
+        "tank/persisted-state/chatgpt-desktop".mountpoint = "/home/${config.primary-user.name}/.config/ChatGPT";
         "tank/persisted-state/chromium".mountpoint = "/home/${config.primary-user.name}/.config/chromium";
         "tank/persisted-state/claude-code".mountpoint = "/home/${config.primary-user.name}/.claude";
         "tank/persisted-state/claude-desktop".mountpoint = "/home/${config.primary-user.name}/.config/Claude";
+        "tank/persisted-state/codex".mountpoint = "/home/${config.primary-user.name}/.codex";
         "tank/persisted-state/containers".mountpoint = "/home/${config.primary-user.name}/.local/share/containers";
         "tank/persisted-state/direnv-allow".mountpoint = "/home/${config.primary-user.name}/.local/share/direnv/allow";
         "tank/persisted-state/discord".mountpoint = "/home/${config.primary-user.name}/.config/discord";

--- a/config/machines/lyra/default.nix
+++ b/config/machines/lyra/default.nix
@@ -109,6 +109,8 @@ in {
         "tank/persisted-state/argo".mountpoint = "/home/${config.primary-user.name}/.config/argo";
         "tank/persisted-state/bluetooth".mountpoint = "/var/lib/bluetooth";
         "tank/persisted-state/chromium".mountpoint = "/home/${config.primary-user.name}/.config/chromium";
+        "tank/persisted-state/claude-code".mountpoint = "/home/${config.primary-user.name}/.claude";
+        "tank/persisted-state/claude-desktop".mountpoint = "/home/${config.primary-user.name}/.config/Claude";
         "tank/persisted-state/containers".mountpoint = "/home/${config.primary-user.name}/.local/share/containers";
         "tank/persisted-state/direnv-allow".mountpoint = "/home/${config.primary-user.name}/.local/share/direnv/allow";
         "tank/persisted-state/discord".mountpoint = "/home/${config.primary-user.name}/.config/discord";

--- a/config/modules/ui/launcher/default.nix
+++ b/config/modules/ui/launcher/default.nix
@@ -28,8 +28,14 @@
     '';
 in {
   nixpkgs.overlays = [
+    (import ../../../../pkgs/claude-desktop/overlay.nix)
     (import ../../../../pkgs/launcher/overlay.nix)
   ];
+
+  # Cowork runs its sandbox VM through KVM, and it opens /dev/vhost-vsock,
+  # which only members of this group can, whatever /dev/kvm's own permissions
+  # are.  See https://code.claude.com/docs/en/desktop-linux
+  primary-user.extraGroups = ["kvm"];
 
   primary-user.home-manager = {
     home.packages = lib.mkForce [pkgs.launcher];
@@ -49,6 +55,7 @@ in {
           calendar = mkGoogleApp "calendar" "https://calendar.google.com";
           chrome = pkgs.writeShellScript "chrome" "${pkgs.launcher}/bin/browse --browser chrome $*";
           chromium = pkgs.writeShellScript "chromium" "${pkgs.launcher}/bin/browse --browser chromium $*";
+          claude = "${pkgs.claude-desktop}/bin/claude-desktop";
           credit-cards = mkWebApp "credit-cards" "https://docs.google.com/spreadsheets/d/1Y8xind-5nMe9bezMFmk__CQdkSBd7FPupt1NkdKDLUE?authuser=connor@prussin.net";
           crux = mkTerminalApp "crux" "${pkgs.openssh}/bin/ssh -t crux load-session";
           cups = mkWebApp "cups" "http://localhost:631";

--- a/config/modules/ui/launcher/default.nix
+++ b/config/modules/ui/launcher/default.nix
@@ -28,6 +28,7 @@
     '';
 in {
   nixpkgs.overlays = [
+    (import ../../../../pkgs/chatgpt-desktop/overlay.nix)
     (import ../../../../pkgs/claude-desktop/overlay.nix)
     (import ../../../../pkgs/launcher/overlay.nix)
   ];
@@ -53,6 +54,7 @@ in {
           brightness = pkgs.callPackage ./apps/brightness.nix {};
           btop = mkTerminalApp "btop" "${pkgs.btop}/bin/btop";
           calendar = mkGoogleApp "calendar" "https://calendar.google.com";
+          chatgpt = "${pkgs.chatgpt-desktop}/bin/chatgpt";
           chrome = pkgs.writeShellScript "chrome" "${pkgs.launcher}/bin/browse --browser chrome $*";
           chromium = pkgs.writeShellScript "chromium" "${pkgs.launcher}/bin/browse --browser chromium $*";
           claude = "${pkgs.claude-desktop}/bin/claude-desktop";

--- a/pkgs/chatgpt-desktop/default.nix
+++ b/pkgs/chatgpt-desktop/default.nix
@@ -1,0 +1,8 @@
+{nixpkgs ? (import ../../sources.nix).nixpkgs}: let
+  pkgs = import nixpkgs {
+    overlays = [
+      (import ./overlay.nix)
+    ];
+  };
+in
+  pkgs.chatgpt-desktop

--- a/pkgs/chatgpt-desktop/derivation.nix
+++ b/pkgs/chatgpt-desktop/derivation.nix
@@ -1,0 +1,222 @@
+# OpenAI ships the Linux app as a .deb from their own apt repo and there's no
+# nixpkgs package for it (`pkgs.chatgpt` is the macOS .dmg, darwin-only), so we
+# unpack that .deb the same way `claude-desktop` does.  The URL layout and the
+# per-arch hashes come from the AUR `chatgpt-desktop` PKGBUILD, which repackages
+# the same binaries.
+#
+# `version` and `hash` move together; the pool this reads from is listed at
+# https://persistent.oaistatic.com/codex-app-prod/linux/deb/dists/stable/main/binary-amd64/Packages
+{
+  lib,
+  stdenv,
+  fetchurl,
+  alsa-lib,
+  at-spi2-core,
+  autoPatchelfHook,
+  cairo,
+  cups,
+  dbus,
+  dpkg,
+  expat,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  graphite2,
+  gtk3,
+  libGL,
+  libdrm,
+  libgbm,
+  libnotify,
+  libpulseaudio,
+  libsecret,
+  libusb1,
+  libuuid,
+  libx11,
+  libxcb,
+  libxcomposite,
+  libxcursor,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxi,
+  libxkbcommon,
+  libxrandr,
+  libxrender,
+  libxscrnsaver,
+  libxtst,
+  makeWrapper,
+  mesa,
+  nspr,
+  nss,
+  pango,
+  systemd,
+  vulkan-loader,
+  wayland,
+  wrapGAppsHook3,
+  xdg-utils,
+}: let
+  version = "26.820.71523";
+
+  sources = {
+    x86_64-linux = {
+      debArch = "amd64";
+      hash = "sha256-Ry0D6IophX8QFbK5F12AUjoTHPG8PpAX6xqP8jTeG9o=";
+    };
+    aarch64-linux = {
+      debArch = "arm64";
+      hash = "sha256-4OyqrqaqROfkWMky9c12EueGwK6wi+2XHLlq48QmYBM=";
+    };
+  };
+
+  source =
+    sources.${stdenv.hostPlatform.system}
+    or (throw "chatgpt-desktop is not packaged for ${stdenv.hostPlatform.system}");
+
+  runtimeLibs = [
+    alsa-lib
+    at-spi2-core
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    graphite2
+    gtk3
+    libGL
+    libdrm
+    libgbm
+    libnotify
+    libpulseaudio
+    libsecret
+    libusb1
+    libuuid
+    libx11
+    libxcb
+    libxcomposite
+    libxcursor
+    libxdamage
+    libxext
+    libxfixes
+    libxi
+    libxkbcommon
+    libxrandr
+    libxrender
+    libxscrnsaver
+    libxtst
+    mesa
+    nspr
+    nss
+    pango
+    stdenv.cc.cc.lib
+    systemd
+    vulkan-loader
+    wayland
+  ];
+in
+  stdenv.mkDerivation {
+    pname = "chatgpt-desktop";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://persistent.oaistatic.com/codex-app-prod/linux/deb/pool/main/c/chatgpt/chatgpt_${version}_${source.debArch}.deb";
+      inherit (source) hash;
+    };
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      dpkg
+      makeWrapper
+      wrapGAppsHook3
+    ];
+
+    buildInputs = runtimeLibs;
+
+    # Libraries the .deb ships that nothing here will load: the Qt shims
+    # Electron picks at runtime to match a Qt desktop's theme (this one is
+    # GTK), and the musl and Android builds of a few node addons, which sit
+    # beside the glibc ones that actually get loaded.  Listed out rather than
+    # blanket-ignored, so a library that does matter still fails the build.
+    autoPatchelfIgnoreMissingDeps = [
+      "libQt5Core.so.5"
+      "libQt5Gui.so.5"
+      "libQt5Widgets.so.5"
+      "libQt6Core.so.6"
+      "libQt6Gui.so.6"
+      "libQt6Widgets.so.6"
+      "libc++_shared.so"
+      "libc.musl-aarch64.so.1"
+      "libc.musl-x86_64.so.1"
+      "liblog.so"
+    ];
+
+    dontConfigure = true;
+    dontBuild = true;
+    dontStrip = true;
+    dontWrapGApps = true;
+
+    unpackPhase = ''
+      runHook preUnpack
+      dpkg-deb --fsys-tarfile "$src" | tar --extract --file - --no-same-permissions
+      runHook postUnpack
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/bin" "$out/lib" "$out/share"
+      cp -a usr/lib/chatgpt "$out/lib/"
+      cp -a usr/share/applications usr/share/doc "$out/share/"
+
+      # This .deb ships no icon theme dir today, and where it would put one if
+      # that changes isn't worth guessing at.
+      for dir in icons pixmaps
+      do
+        if test -d "usr/share/$dir"
+        then
+          cp -a "usr/share/$dir" "$out/share/"
+        fi
+      done
+
+      for desktop in "$out"/share/applications/*.desktop
+      do
+        substituteInPlace "$desktop" \
+          --replace-fail "Exec=chatgpt" "Exec=$out/bin/chatgpt"
+      done
+
+      # `codex-launcher` is upstream's entry point, not the ChatGPT binary
+      # beside it: it reads ~/.config/chatgpt-flags.conf and prepends those
+      # flags before exec'ing its sibling.  It resolves that sibling from its
+      # own path, so wrapping the sibling in place below is what gets the
+      # environment onto it.
+      test -e "$out/lib/chatgpt/codex-launcher" \
+        || (echo "no codex-launcher in this .deb -- wrap ChatGPT directly" >&2; exit 1)
+      ln -s ../lib/chatgpt/codex-launcher "$out/bin/chatgpt"
+
+      runHook postInstall
+    '';
+
+    preFixup = ''
+      gappsWrapperArgs+=(
+        --prefix PATH : ${lib.makeBinPath [xdg-utils]}
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath runtimeLibs}
+        --set-default ELECTRON_OZONE_PLATFORM_HINT auto
+      )
+    '';
+
+    postFixup = ''
+      wrapProgram "$out/lib/chatgpt/ChatGPT" "''${gappsWrapperArgs[@]}"
+    '';
+
+    meta = {
+      description = "Official ChatGPT desktop app for Linux";
+      homepage = "https://chatgpt.com/download";
+      license = lib.licenses.unfree;
+      mainProgram = "chatgpt";
+      platforms = builtins.attrNames sources;
+      sourceProvenance = [lib.sourceTypes.binaryNativeCode];
+    };
+  }

--- a/pkgs/chatgpt-desktop/overlay.nix
+++ b/pkgs/chatgpt-desktop/overlay.nix
@@ -1,0 +1,3 @@
+self: _: {
+  chatgpt-desktop = self.callPackage ./derivation.nix {};
+}

--- a/pkgs/claude-desktop/default.nix
+++ b/pkgs/claude-desktop/default.nix
@@ -1,0 +1,8 @@
+{nixpkgs ? (import ../../sources.nix).nixpkgs}: let
+  pkgs = import nixpkgs {
+    overlays = [
+      (import ./overlay.nix)
+    ];
+  };
+in
+  pkgs.claude-desktop

--- a/pkgs/claude-desktop/derivation.nix
+++ b/pkgs/claude-desktop/derivation.nix
@@ -1,0 +1,228 @@
+# Anthropic ships the Linux app as a .deb from their own apt repo and there's
+# no nixpkgs package for it, so we unpack that .deb ourselves.  The recipe --
+# in particular the two paths patched inside app.asar, without which Cowork
+# can't find QEMU's firmware -- is adapted from
+# https://github.com/poeck/claude-desktop-nix-flake (MIT).
+#
+# `version` and `hash` move together: bump both from the pool listing at
+# https://downloads.claude.ai/claude-desktop/apt/stable/dists/stable/main/binary-amd64/Packages
+{
+  lib,
+  stdenv,
+  fetchurl,
+  alsa-lib,
+  asar,
+  at-spi2-core,
+  autoPatchelfHook,
+  cairo,
+  cups,
+  dbus,
+  dpkg,
+  expat,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libGL,
+  libayatana-appindicator,
+  libcap_ng,
+  libdrm,
+  libgbm,
+  libnotify,
+  libpulseaudio,
+  libseccomp,
+  libsecret,
+  libuuid,
+  libva,
+  libx11,
+  libxcb,
+  libxcomposite,
+  libxcursor,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxi,
+  libxkbcommon,
+  libxrandr,
+  libxrender,
+  libxscrnsaver,
+  libxtst,
+  makeWrapper,
+  mesa,
+  nspr,
+  nss,
+  OVMF,
+  pango,
+  perl,
+  qemu,
+  systemd,
+  trash-cli,
+  vulkan-loader,
+  wayland,
+  wrapGAppsHook3,
+  xdg-utils,
+}: let
+  version = "1.18286.2";
+
+  sources = {
+    x86_64-linux = {
+      debArch = "amd64";
+      hash = "sha256-Vvpd4FPgpo3HWDZ3hXvtz0IZsZ2QIBQA4CN7fXTVEvE=";
+    };
+    aarch64-linux = {
+      debArch = "arm64";
+      hash = "sha256-OMZaEibczHWmskGLnUwGT0+dxTMfiWCK7dVU2H1Sm6M=";
+    };
+  };
+
+  source =
+    sources.${stdenv.hostPlatform.system}
+    or (throw "claude-desktop is not packaged for ${stdenv.hostPlatform.system}");
+
+  firmwareCodePath =
+    if stdenv.hostPlatform.isAarch64
+    then "${qemu}/share/qemu/edk2-aarch64-code.fd"
+    else "${OVMF.fd}/FV/OVMF_CODE.fd";
+
+  runtimeLibs = [
+    alsa-lib
+    at-spi2-core
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    libGL
+    libayatana-appindicator
+    libcap_ng
+    libdrm
+    libgbm
+    libnotify
+    libpulseaudio
+    libseccomp
+    libsecret
+    libuuid
+    libva
+    libx11
+    libxcb
+    libxcomposite
+    libxcursor
+    libxdamage
+    libxext
+    libxfixes
+    libxi
+    libxkbcommon
+    libxrandr
+    libxrender
+    libxscrnsaver
+    libxtst
+    mesa
+    nspr
+    nss
+    pango
+    stdenv.cc.cc.lib
+    systemd
+    vulkan-loader
+    wayland
+  ];
+
+  runtimeBins = [
+    glib
+    qemu
+    trash-cli
+    xdg-utils
+  ];
+in
+  stdenv.mkDerivation {
+    pname = "claude-desktop";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_${version}_${source.debArch}.deb";
+      inherit (source) hash;
+    };
+
+    nativeBuildInputs = [
+      asar
+      autoPatchelfHook
+      dpkg
+      makeWrapper
+      perl
+      wrapGAppsHook3
+    ];
+
+    buildInputs = runtimeLibs;
+
+    dontConfigure = true;
+    dontBuild = true;
+    dontStrip = true;
+    dontWrapGApps = true;
+
+    unpackPhase = ''
+      runHook preUnpack
+      dpkg-deb --fsys-tarfile "$src" | tar --extract --file - --no-same-permissions
+      runHook postUnpack
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/lib" "$out/share"
+      cp -a usr/lib/claude-desktop "$out/lib/"
+      cp -a usr/share/applications usr/share/icons usr/share/doc "$out/share/"
+
+      substituteInPlace "$out/share/applications/claude-desktop.desktop" \
+        --replace-fail "Exec=claude-desktop" "Exec=$out/bin/claude-desktop"
+
+      # The .deb bundles virtiofsd for distros that don't package it; the patch
+      # below points Cowork at that copy, and unlike the three rewrites it has
+      # nothing to fail against if a release drops it.  If this ever fires,
+      # nixpkgs has a `virtiofsd` to point at instead.
+      test -e "$out/lib/claude-desktop/resources/virtiofsd" \
+        || (echo "no bundled virtiofsd in this .deb -- use pkgs.virtiofsd" >&2; exit 1)
+
+      asarRoot="$(mktemp -d)"
+      asar extract "$out/lib/claude-desktop/resources/app.asar" "$asarRoot"
+
+      FIRMWARE_CODE_PATH="${firmwareCodePath}" \
+      VIRTIOFSD_PATH="$out/lib/claude-desktop/resources/virtiofsd" \
+      perl -0pi -e '
+        s{([A-Za-z0-9_\$]+)=process\.arch==="arm64"\?\["/usr/share/AAVMF/AAVMF_CODE\.fd"\]:\["/usr/share/OVMF/OVMF_CODE_4M\.fd","/usr/share/OVMF/OVMF_CODE\.fd"\]}{$1=["$ENV{FIRMWARE_CODE_PATH}"]} or die "failed to patch firmware path\n";
+        s{([A-Za-z0-9_\$]+)=\["/usr/libexec/virtiofsd","/usr/bin/virtiofsd"\]}{$1=["$ENV{VIRTIOFSD_PATH}"]} or die "failed to patch virtiofsd path\n";
+        s{return A\.replace\("OVMF_CODE","OVMF_VARS"\)\.replace\("AAVMF_CODE","AAVMF_VARS"\)}{return A.replace("OVMF_CODE","OVMF_VARS").replace("AAVMF_CODE","AAVMF_VARS").replace("edk2-aarch64-code.fd","edk2-arm-vars.fd")} or die "failed to patch firmware vars path\n";
+      ' "$asarRoot/.vite/build/index.js"
+
+      rm "$out/lib/claude-desktop/resources/app.asar"
+      asar pack --unpack "*.node" "$asarRoot" "$out/lib/claude-desktop/resources/app.asar"
+
+      runHook postInstall
+    '';
+
+    preFixup = ''
+      gappsWrapperArgs+=(
+        --prefix PATH : ${lib.makeBinPath runtimeBins}
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath runtimeLibs}
+        --set-default ELECTRON_OZONE_PLATFORM_HINT auto
+      )
+    '';
+
+    postFixup = ''
+      makeWrapper "$out/lib/claude-desktop/claude-desktop" "$out/bin/claude-desktop" \
+        "''${gappsWrapperArgs[@]}"
+    '';
+
+    meta = {
+      description = "Official Claude Desktop Linux beta";
+      homepage = "https://claude.ai";
+      changelog = "https://code.claude.com/docs/en/desktop-linux";
+      license = lib.licenses.unfree;
+      mainProgram = "claude-desktop";
+      platforms = builtins.attrNames sources;
+      sourceProvenance = [lib.sourceTypes.binaryNativeCode];
+    };
+  }

--- a/pkgs/claude-desktop/overlay.nix
+++ b/pkgs/claude-desktop/overlay.nix
@@ -1,0 +1,3 @@
+self: _: {
+  claude-desktop = self.callPackage ./derivation.nix {};
+}


### PR DESCRIPTION
Replaces #17, which took the wrong approach (browser app-mode windows). This packages the real apps. Two commits, independent of each other — the ChatGPT one can be dropped without touching the Claude one.

Neither app is in nixpkgs for Linux (`pkgs.chatgpt` is the macOS `.dmg`, darwin-only), and both now ship an official `.deb` from a vendor apt repo, so both packages unpack that `.deb`.

**Claude** (`pkgs/claude-desktop`) — recipe adapted from [poeck/claude-desktop-nix-flake](https://github.com/poeck/claude-desktop-nix-flake) (MIT), including the two paths patched inside `app.asar`, without which Cowork looks for QEMU's firmware under `/usr/share` and reports it missing. The bundled `virtiofsd` gets an existence check, since unlike the three rewrites nothing else fails if a release drops it. The launcher module also joins the `kvm` group, which Cowork needs for `/dev/vhost-vsock`.

**ChatGPT** (`pkgs/chatgpt-desktop`) — same shape, minus the QEMU patching. The pool URL layout and both per-arch hashes come from the AUR `chatgpt-desktop` PKGBUILD, which repackages the same binaries; the `.deb` itself is fetched from OpenAI over TLS, so a wrong third-party hash can only fail the build, never substitute content. `bin/chatgpt` is upstream's `codex-launcher`, so `~/.config/chatgpt-flags.conf` keeps working; the wrapper goes on the binary it execs. Electron's Qt theme shims and the musl/Android node prebuilds are ignored by name, so a library that does matter still fails the build.

**Datasets on lyra** (the root is a tmpfs), named for which half of each app they hold rather than for their directories, so no two differ only in case:

| dataset | mountpoint |
|---|---|
| `claude-desktop` | `~/.config/Claude` |
| `claude-code` | `~/.claude` |
| `chatgpt-desktop` | `~/.config/ChatGPT` |
| `codex` | `~/.codex` |

Both packages join the `build-pkgs` matrix — they are the derivations here whose install phases depend on content the flake doesn't pin, which is what that job exists to catch. It paid for itself immediately: the ChatGPT `.deb` ships no `usr/share/icons`, and carries libraries nothing here loads. Eval caught neither.

Verified by CI building both for real: the hashes, the asar patches, the virtiofsd and `codex-launcher` guards. Not verified — anything needing the apps running: Cowork's VM and whether its disk images want persisting too. `~/.codex` rests on Gentoo's post-install note for this package and on numtide's packaging of the same series, not on observation.