### PR TITLE
[launcher] Fix the ChatGPT app's store copies, environment and Wayland backend

### DIFF
--- a/pkgs/chatgpt-desktop/derivation.nix
+++ b/pkgs/chatgpt-desktop/derivation.nix
@@ -14,6 +14,7 @@
   at-spi2-core,
   autoPatchelfHook,
   cairo,
+  coreutils,
   cups,
   dbus,
   dpkg,
@@ -50,6 +51,7 @@
   nspr,
   nss,
   pango,
+  python3,
   systemd,
   vulkan-loader,
   wayland,
@@ -72,6 +74,13 @@
   source =
     sources.${stdenv.hostPlatform.system}
     or (throw "chatgpt-desktop is not packaged for ${stdenv.hostPlatform.system}");
+
+  # coreutils is load-bearing: the asar patch below makes the app copy its
+  # bundled plugins with `cp` and `chmod` rather than node's fs.cp.
+  runtimeBins = [
+    coreutils
+    xdg-utils
+  ];
 
   runtimeLibs = [
     alsa-lib
@@ -130,6 +139,7 @@ in
       autoPatchelfHook
       dpkg
       makeWrapper
+      python3
       wrapGAppsHook3
     ];
 
@@ -187,6 +197,14 @@ in
           --replace-fail "Exec=chatgpt" "Exec=$out/bin/chatgpt"
       done
 
+      # Two things the app does that only break on NixOS: it materializes its
+      # bundled plugins into ~/.codex with node's fs.cp, which preserves the
+      # store's read-only modes and then can't write the manifests it rewrites
+      # (EACCES on every launch), and @parcel/watcher probes `process.report`,
+      # which trips a CFI guard in the bundled Electron runtime.  Both patches
+      # fail the build if the code they match has moved.
+      python3 ${./patch-asar.py} "$out/lib/chatgpt/resources/app.asar"
+
       # `codex-launcher` is upstream's entry point, not the ChatGPT binary
       # beside it: it reads ~/.config/chatgpt-flags.conf and prepends those
       # flags before exec'ing its sibling.  It resolves that sibling from its
@@ -201,7 +219,7 @@ in
 
     preFixup = ''
       gappsWrapperArgs+=(
-        --prefix PATH : ${lib.makeBinPath [xdg-utils]}
+        --prefix PATH : ${lib.makeBinPath runtimeBins}
         --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath runtimeLibs}
         --set-default ELECTRON_OZONE_PLATFORM_HINT auto
       )

--- a/pkgs/chatgpt-desktop/derivation.nix
+++ b/pkgs/chatgpt-desktop/derivation.nix
@@ -51,6 +51,7 @@
   nspr,
   nss,
   pango,
+  pipewire,
   python3,
   systemd,
   vulkan-loader,
@@ -145,6 +146,26 @@ in
 
     buildInputs = runtimeLibs;
 
+    # Electron dlopens these rather than linking them, so autoPatchelf has to
+    # be told: they go on each executable's RPATH.  What they must not do is
+    # arrive as an LD_LIBRARY_PATH on the app's environment -- see the wrapper
+    # below.
+    runtimeDependencies = [
+      libGL
+      libgbm
+      libnotify
+      libpulseaudio
+      libsecret
+      pipewire
+      vulkan-loader
+      wayland
+      # systemd has no `lib` output at this nixpkgs rev, so this resolves to
+      # the same path as bare `systemd` and is only here to stay correct if one
+      # is ever added.  libudev.so.1 does live in its $out/lib, which is where
+      # the hook looks: it appends /lib to whatever path it is given.
+      (lib.getLib systemd)
+    ];
+
     # Libraries the .deb ships that nothing here will load: the Qt shims
     # Electron picks at runtime to match a Qt desktop's theme (this one is
     # GTK), and the musl and Android builds of a few node addons, which sit
@@ -206,10 +227,11 @@ in
       python3 ${./patch-asar.py} "$out/lib/chatgpt/resources/app.asar"
 
       # `codex-launcher` is upstream's entry point, not the ChatGPT binary
-      # beside it: it reads ~/.config/chatgpt-flags.conf and prepends those
-      # flags before exec'ing its sibling.  It resolves that sibling from its
-      # own path, so wrapping the sibling in place below is what gets the
-      # environment onto it.
+      # beside it: a two-line script that resolves its sibling from its own
+      # path and execs it.  The wrapper goes on that sibling because ChatGPT is
+      # the process that needs the flags and the environment, and wrapping it
+      # also covers anything that runs it directly rather than via the
+      # launcher.
       test -e "$out/lib/chatgpt/codex-launcher" \
         || (echo "no codex-launcher in this .deb -- wrap ChatGPT directly" >&2; exit 1)
       ln -s ../lib/chatgpt/codex-launcher "$out/bin/chatgpt"
@@ -217,16 +239,29 @@ in
       runHook postInstall
     '';
 
+    # The ozone flag rather than ELECTRON_OZONE_PLATFORM_HINT, which this
+    # Electron fork ignores; guarded on WAYLAND_DISPLAY so an X11 session is
+    # unaffected.  Being flagsBefore, a `--ozone-platform=` passed on the
+    # command line still wins, which is the way back to XWayland.
     preFixup = ''
       gappsWrapperArgs+=(
-        --prefix PATH : ${lib.makeBinPath runtimeBins}
-        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath runtimeLibs}
-        --set-default ELECTRON_OZONE_PLATFORM_HINT auto
+        # --suffix, not --prefix (which is what claude-desktop uses): every
+        # child inherits this, including the codex agent shelling out in a
+        # project of mine, and it should get my coreutils rather than the
+        # app's.  The store copy is only the fallback that makes the asar
+        # patch's `cp`/`chmod` work when PATH has neither.
+        --suffix PATH : ${lib.makeBinPath runtimeBins}
+        --add-flags "\''${WAYLAND_DISPLAY:+--ozone-platform=wayland}"
       )
     '';
 
+    # `wrapProgramShell`, not `wrapProgram`: wrapGAppsHook3 propagates
+    # makeBinaryWrapper, which redefines `wrapProgram` to emit a C wrapper that
+    # passes --add-flags through verbatim -- the `${WAYLAND_DISPLAY:+...}` above
+    # would reach Electron as a literal argument instead of expanding.  The
+    # shell flavour stays available because makeWrapper is in nativeBuildInputs.
     postFixup = ''
-      wrapProgram "$out/lib/chatgpt/ChatGPT" "''${gappsWrapperArgs[@]}"
+      wrapProgramShell "$out/lib/chatgpt/ChatGPT" "''${gappsWrapperArgs[@]}"
     '';
 
     meta = {

--- a/pkgs/chatgpt-desktop/patch-asar.py
+++ b/pkgs/chatgpt-desktop/patch-asar.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Apply byte-length-preserving source patches inside app.asar.
+
+Vendored from numtide/llm-agents.nix (MIT), which hit the same two problems.
+
+The asar header records file offsets, so every replacement is padded with
+spaces to the original's exact byte length instead of re-packing the archive.
+Minified identifiers change between releases, so patterns are regexes that
+capture the identifiers they need instead of hard-coding them.
+"""
+
+import re
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+# @parcel/watcher uses detect-libc in a named worker. Its process.report
+# fallback trips a CFI guard in the bundled Owl/Electron runtime on NixOS.
+# detect-libc falls back to its ELF/filesystem/ldd probes instead.
+SKIP_PROCESS_REPORT = (
+    re.compile(rb"isLinux\(\) && process\.report"),
+    lambda _m: b"false /* nix:skip report */",
+)
+
+# The app materializes bundled plugins in ~/.codex and rewrites selected
+# manifests there. Node's fs.cp preserves the Nix store's read-only modes,
+# so copy with coreutils and make only the user-owned destination writable.
+# `exec` is the promisified execFile helper already used for the darwin
+# `ditto` branch. Hoisting `platform` into a local buys the bytes needed.
+COPY_PLUGINS_WRITABLE = (
+    re.compile(
+        rb"(?P<fn>async function [\w$]+\(e,t\)\{)"
+        rb"if\((?P<plat>[\w$]+\.default\.platform)===`darwin`\)"
+        rb"(?P<ditto>\{await (?P<exec>[\w$]+)\(`/usr/bin/ditto`,\[`--noqtn`,e,t\]\);return\})"
+        rb"if\((?P=plat)!==`win32`\)\{"
+        rb"await [\w$]+\.default\.cp\(e,t,\{recursive:!0,verbatimSymlinks:!0\}\);return\}"
+    ),
+    lambda m: (
+        m["fn"]
+        + b"let r="
+        + m["plat"]
+        + b";if(r===`darwin`)"
+        + m["ditto"]
+        + b"if(r!==`win32`){await "
+        + m["exec"]
+        + b"(`cp`,[`-r`,e+`/.`,t]);await "
+        + m["exec"]
+        + b"(`chmod`,[`-R`,`u+w`,t]);return}"
+    ),
+)
+
+PATCHES: list[tuple[re.Pattern[bytes], Callable[[re.Match[bytes]], bytes]]] = [
+    SKIP_PROCESS_REPORT,
+    COPY_PLUGINS_WRITABLE,
+]
+
+
+def main() -> None:
+    """Patch the asar archive given as the only argument."""
+    asar = Path(sys.argv[1])
+    data = asar.read_bytes()
+    for pattern, build in PATCHES:
+        matches = list(pattern.finditer(data))
+        if len(matches) != 1:
+            sys.exit(
+                f"expected 1 match for {pattern.pattern[:60]!r} in {asar}, got {len(matches)}"
+            )
+        m = matches[0]
+        original = m.group(0)
+        replacement = build(m)
+        if len(replacement) > len(original):
+            sys.exit(f"replacement longer than original: {replacement[:60]!r}...")
+        data = (
+            data[: m.start()] + replacement.ljust(len(original), b" ") + data[m.end() :]
+        )
+    asar.write_bytes(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/chatgpt-desktop/patch-asar.py
+++ b/pkgs/chatgpt-desktop/patch-asar.py
@@ -1,7 +1,29 @@
 #!/usr/bin/env python3
 """Apply byte-length-preserving source patches inside app.asar.
 
-Vendored from numtide/llm-agents.nix (MIT), which hit the same two problems.
+Vendored from numtide/llm-agents.nix, packages/chatgpt/patch-asar.py, taken
+from main on 2026-08-28; diff against that path to re-sync when a version bump
+moves the minified code these patterns match.
+
+Copyright (c) 2024 Numtide
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 The asar header records file offsets, so every replacement is padded with
 spaces to the original's exact byte length instead of re-packing the archive.


### PR DESCRIPTION
Follow-up to #18. Three defects, two commits.

### 1. EACCES under `~/.codex` on every launch

The app materializes its bundled plugins there with node's `fs.cp`, which preserves the mode of what it copies — and everything it copies comes out of the Nix store read-only. It then can't rewrite the manifests it just wrote, so `bundled_plugins_marketplace_resolve_failed` every launch.

`patch-asar.py` is vendored from [numtide/llm-agents.nix](https://github.com/numtide/llm-agents.nix) (MIT), which hit the same two NixOS-specific problems: that copy (rewritten to `cp` + `chmod u+w`, hence coreutils on PATH), and a `process.report` probe in `@parcel/watcher` that trips a CFI guard in the bundled Electron. Both abort the build if the minified code they match moves.

### 2. Sign-in fails — LD_LIBRARY_PATH leaking into every child

Symptom: a flash of "Continue to sign in on your browser", no browser, then the sign-in screen again; a second click says a login is already in progress.

Login is driven by the bundled `codex` binary, which spawns the browser itself. Run that binary from a shell and the browser comes up; run it as a child of the app and it doesn't. The wrapper was exporting an `LD_LIBRARY_PATH` of forty Electron/GTK libraries, inherited by `codex`, by `xdg-open`, and by the browser those reach.

Electron needs them only on the objects that dlopen them — autoPatchelf's `runtimeDependencies`. numtide reached the same conclusion in as many words: *"without leaking a broad LD_LIBRARY_PATH into Electron's Node and Chromium children."*

Worth recording: the round-2 reviewer on #18 flagged exactly this as "the first thing to try if QEMU misbehaves". It was a defect, not a note. **`claude-desktop` still carries the same LD_LIBRARY_PATH** — untouched here since nothing has misbehaved, but that's where to start if Cowork's QEMU ever does.

### 3. XWayland instead of native Wayland

`ELECTRON_OZONE_PLATFORM_HINT` is a hint this Electron fork ignores. Replaced with `--ozone-platform=wayland`, guarded on `WAYLAND_DISPLAY` so an X11 session is unaffected.

**Verified by CI only** — it builds, and the asar patches are proven to apply. Whether 2 and 3 do what they claim needs your machine: after deploying, sign-in should reach the browser, and `swaymsg -t get_tree | grep -i chatgpt` should show an `app_id` rather than X11 `window_properties`.