### PR TITLE
[claude-code] Remind about the PR review rule with a repo hook

### DIFF
--- a/.claude/hooks/pr-review-reminder.sh
+++ b/.claude/hooks/pr-review-reminder.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Reminds Claude Code to spawn a reviewer after it pushes.
+#
+# The rule itself is in CLAUDE.md, but a document is read once at session start
+# and then competes with everything else in context.  A hook on the push itself
+# puts the instruction in front of the model at the one moment it applies.
+#
+# This reminds; it does not compel.  PostToolUse output is advisory context,
+# and the model can read it and still end the turn.  Only a Stop hook can
+# refuse to end one, and blocking there loops when a reviewer legitimately
+# isn't needed.
+
+set -eu
+
+# Anything that goes wrong in here leaves the hook doing nothing, and a hook
+# doing nothing looks exactly like a session that never pushed.  Say so out
+# loud instead.  It has to be a systemMessage on stdout rather than a line on
+# stderr: Claude Code only surfaces a hook's stderr when the hook exits
+# non-zero, and exiting non-zero here would report a broken push instead.
+warn() {
+  printf '{"systemMessage":"pr-review-reminder: %s"}\n' "$1"
+  exit 0
+}
+
+# `--version` as well as `command -v`, because jq present but not working --
+# a dangling symlink, a wrong-arch binary, a wrapper that errors -- fails the
+# same silent way jq missing does.
+if ! command -v jq > /dev/null 2>&1 || ! jq --version > /dev/null 2>&1
+then
+  warn "jq is missing or not working, so PR-review reminders are off"
+fi
+
+payload=$(cat)
+event=$(printf '%s' "$payload" | jq -r '.hook_event_name // "PostToolUse"') \
+  || warn "could not read hook_event_name from the hook payload"
+command=$(printf '%s' "$payload" | jq -r '.tool_input.command // ""') \
+  || warn "could not read tool_input.command from the hook payload"
+
+# Split the command on the shell operators that separate one command from the
+# next, drop any segment whose push is a dry run, and look for a git push in
+# what's left.  Splitting first is what makes `git push --dry-run && git push`
+# fire while `git push --dry-run` alone doesn't.
+#
+# The dry-run test only counts -n and --dry-run appearing *after* `push`, so
+# `xargs -n 1 git push` and `sort -n f && git push` still fire -- an unrelated
+# -n earlier in the segment isn't git's.
+#
+# The leading boundary is "not part of a longer word" rather than "at a command
+# position", so `sudo git push`, `time git push`, `nix develop -c git push` and
+# a leading VAR=value all still match, while `legit pushed` doesn't.  That
+# direction is deliberate: a missed push means a PR goes unreviewed, which
+# defeats the hook, whereas a spurious reminder costs one wasted reviewer
+# spawn.  The loose end goes where it's cheap.
+#
+# No `set -o pipefail` here, deliberately: `grep -Eq` exits at the first match
+# and SIGPIPEs the grep feeding it, so under pipefail the pipeline would go
+# non-zero on exactly the inputs that should fire, and the hook would go quiet.
+# shellcheck disable=SC2020  # a set of chars is exactly what's wanted here
+if ! printf '%s' "$command" \
+  | tr ';&|' '\n\n\n' \
+  | grep -Ev -- 'push[[:space:]]+([^[:space:]]+[[:space:]]+)*(-n|--dry-run)([[:space:]]|$)' \
+  | grep -Eq '(^|[^[:alnum:]_./-])git[[:space:]]+.*push([^[:alnum:]_-]|$)'
+then
+  exit 0
+fi
+
+# PostToolUseFailure covers a push chained ahead of something that failed --
+# the Bash tool throws on any non-zero exit -- but it also fires for a push the
+# remote rejected, or one that was interrupted or timed out.  Claiming a push
+# completed when it didn't would send a reviewer after a head that was never
+# pushed, so that path says what actually happened and lets the model check.
+case $event in
+  PostToolUseFailure)
+    lead="A command containing a git push just ran and failed. If the push \
+itself landed, the rule below applies; confirm before acting on it."
+    ;;
+  *)
+    lead="A git push just completed."
+    ;;
+esac
+
+jq -nc --arg event "$event" --arg lead "$lead" '{
+  hookSpecificOutput: {
+    hookEventName: $event,
+    additionalContext: (
+      $lead
+      + " This repository asks that every pull request you open or modify"
+      + " gets a review sub-agent run against its current head, with no"
+      + " exception for one-line, follow-up or speculative changes, and a"
+      + " force-push invalidates any review that came before it. Spawn that"
+      + " reviewer before ending this turn, or say plainly why the push"
+      + " needs none."
+    )
+  }
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "outputStyle": "Concise",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}/.claude/hooks/pr-review-reminder.sh\""
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR}/.claude/hooks/pr-review-reminder.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /iso-build
 .direnv/
 result
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# Working in this repository
+
+## Pull requests get reviewed by a sub-agent
+
+Every pull request you open or modify gets a review sub-agent run against its
+current head. There is no exception for one-line, follow-up or speculative
+changes, and a force-push invalidates any review that came before it.
+
+Spawn that reviewer before ending the turn in which you pushed, or say plainly
+why the push needs none. `.claude/hooks/pr-review-reminder.sh` will remind you
+after a push, but the rule holds whether or not the reminder fires.
+
+The hook needs `jq`. The dev shell provides it and direnv loads that shell in a
+terminal inside the checkout, so a session started there is fine; one started
+from a desktop launcher or a remote environment may not have it. When the hook
+can't run it warns the user in their terminal, not you -- so treat the rule as
+holding whether or not you ever see a reminder.

--- a/flake.nix
+++ b/flake.nix
@@ -165,6 +165,8 @@
           devShells.default = pkgs.mkShell {
             buildInputs = [
               pkgs.git
+              # The .claude/ PR-review hook shells out to it.
+              pkgs.jq
               pkgs.passwordUtils
               pkgs.colmena
               pkgs.cli


### PR DESCRIPTION
Manages Claude Code's user settings from the repo for the first time: a hook, and `outputStyle`.

**Why.** The standing rule in `CLAUDE.md` — every PR I open or modify gets a review sub-agent — fired reliably on PRs that were the point of a turn, and missed three consecutive pushes on #19, where each push was incidental to answering a question. Memory is consulted when I happen to look; a hook runs whether I do or not.

**What.** A `PostToolUse` hook on `Bash` that recognizes a `git push` and returns the rule as `additionalContext`. It can't spawn the reviewer — only the model can — but it delivers the instruction at the exact moment the trigger fires, which is the failure point.

**`settings.json` is merged, not symlinked.** Claude Code writes to that file itself (`/config` lands there), so a store symlink would break it. The activation script merges the managed fragment over whatever is there. Tradeoff worth knowing: `jq`'s `*` takes arrays whole, so a `PostToolUse` hook added later through `/hooks` gets replaced on the next switch.

**Verified:** both scripts pipe-tested against synthesized payloads — the hook emits the context for `git push -u origin foo --force-with-lease` and exits silently for `ls -la`; the merge preserves an existing `theme` and `PreToolUse` block while adding ours. Not verified: the activation script running under home-manager for real, and whether the hook fires in a live session — that needs a deploy, and `/hooks` may need opening once to reload config.

---
_Generated by [Claude Code](https://claude.ai/code/session_013VHH9pj1eDhtmmfNwE4ZnY)_