### PR TITLE
[launcher] Stop the ChatGPT app answering for every web link

### DIFF
--- a/pkgs/chatgpt-desktop/derivation.nix
+++ b/pkgs/chatgpt-desktop/derivation.nix
@@ -212,10 +212,17 @@ in
         fi
       done
 
+      # The app claims x-scheme-handler/http and https because it has an
+      # in-app browser.  On a machine with no default browser set that makes it
+      # the handler for every web link, and the app resolves the login URL that
+      # way -- so clicking "sign in" re-execs the app, which hands off to the
+      # running instance ("Opening in existing browser session.") and exits,
+      # and no browser ever opens.  It should not be a general web browser.
       for desktop in "$out"/share/applications/*.desktop
       do
         substituteInPlace "$desktop" \
-          --replace-fail "Exec=chatgpt" "Exec=$out/bin/chatgpt"
+          --replace-fail "Exec=chatgpt" "Exec=$out/bin/chatgpt" \
+          --replace-fail "x-scheme-handler/http;x-scheme-handler/https;" ""
       done
 
       # Two things the app does that only break on NixOS: it materializes its

--- a/pkgs/chatgpt-desktop/derivation.nix
+++ b/pkgs/chatgpt-desktop/derivation.nix
@@ -218,6 +218,13 @@ in
       # way -- so clicking "sign in" re-execs the app, which hands off to the
       # running instance ("Opening in existing browser session.") and exits,
       # and no browser ever opens.  It should not be a general web browser.
+      #
+      # This package is in no profile, so the entry here never reaches the MIME
+      # database directly: the app self-installs a copy into
+      # ~/.local/share/applications, which is what was answering.  Patching the
+      # source of that copy governs future ones only -- a copy already there
+      # keeps its claim until the app rewrites it -- so the registered default
+      # in the launcher module is what actually settles the handler.
       for desktop in "$out"/share/applications/*.desktop
       do
         substituteInPlace "$desktop" \

--- a/pkgs/launcher/home-manager-module.nix
+++ b/pkgs/launcher/home-manager-module.nix
@@ -36,19 +36,35 @@ in {
     # app claims it for its in-app browser, so it was answering for every web
     # link on the machine.  Point both routes at the same script instead.
     xdg = {
-      desktopEntries.browse = {
-        name = "Browse";
+      # `xdg.dataFile` rather than `xdg.desktopEntries`, which would be the
+      # obvious option: it installs through `home.packages`, at the normal
+      # priority that every `lib.mkForce [...]` on that list in this repo
+      # discards -- including the one in the module that imports this.  The
+      # entry would silently not exist, and mimeApps below would then point
+      # every web link at nothing at all.  This lands it in
+      # ~/.local/share/applications, which the spec searches ahead of
+      # XDG_DATA_DIRS, so it also doesn't lean on `environment.pathsToLink`.
+      #
+      # %u, not %U: `browse` keeps one target and drops the rest, so claiming
+      # to accept a list would silently lose all but the last URL.
+      dataFile."applications/browse.desktop".source = "${pkgs.makeDesktopItem {
+        name = "browse";
+        desktopName = "Browse";
         genericName = "Web Browser";
-        exec = "${pkgs.launcher}/bin/browse %U";
+        exec = "${pkgs.launcher}/bin/browse %u";
         terminal = false;
         categories = ["Network" "WebBrowser"];
-        mimeType = [
+        mimeTypes = [
           "text/html"
           "x-scheme-handler/http"
           "x-scheme-handler/https"
         ];
-      };
+      }}/share/applications/browse.desktop";
 
+      # This makes ~/.config/mimeapps.list a read-only store symlink, so
+      # `xdg-mime default`, `xdg-settings set default-web-browser` and a
+      # browser's own "make me the default" prompt all stop working.  Defaults
+      # get set here and redeployed, not set at runtime.
       mimeApps = {
         enable = true;
         defaultApplications = {

--- a/pkgs/launcher/home-manager-module.nix
+++ b/pkgs/launcher/home-manager-module.nix
@@ -47,6 +47,9 @@ in {
       #
       # %u, not %U: `browse` keeps one target and drops the rest, so claiming
       # to accept a list would silently lose all but the last URL.
+      configFile."mimeapps.list".force = true;
+      dataFile."applications/mimeapps.list".force = true;
+
       dataFile."applications/browse.desktop".source = "${pkgs.makeDesktopItem {
         name = "browse";
         desktopName = "Browse";
@@ -61,10 +64,16 @@ in {
         ];
       }}/share/applications/browse.desktop";
 
-      # This makes ~/.config/mimeapps.list a read-only store symlink, so
-      # `xdg-mime default`, `xdg-settings set default-web-browser` and a
-      # browser's own "make me the default" prompt all stop working.  Defaults
-      # get set here and redeployed, not set at runtime.
+      # This makes ~/.config/mimeapps.list a read-only store symlink (and the
+      # deprecated copy under ~/.local/share/applications too).  Defaults get
+      # set here and redeployed, not set at runtime.  `xdg-mime default`,
+      # `xdg-settings set` and Electron's `setAsDefaultProtocolClient` are
+      # shell writes that tmp-and-rename, so they replace the symlink and
+      # appear to work -- it is the *next* activation that would then fail, on
+      # an existing plain file it did not create, and `force` makes it
+      # overwrite instead.  (GIO's `g_app_info_set_as_default_for_type`, which
+      # is what Firefox's prompt uses, resolves the symlink first and so just
+      # fails against the read-only store.)
       mimeApps = {
         enable = true;
         defaultApplications = {

--- a/pkgs/launcher/home-manager-module.nix
+++ b/pkgs/launcher/home-manager-module.nix
@@ -28,5 +28,35 @@ in {
         lib.mapAttrsToList (name: path: {inherit name path;}) cfg.apps
       );
     };
+
+    # $BROWSER only reaches things that read it, which desktop apps mostly
+    # don't -- they resolve a web link through the xdg handler for the scheme
+    # and exec that .desktop's Exec line.  Without a default registered, that
+    # picks whichever installed app happens to claim the scheme; the ChatGPT
+    # app claims it for its in-app browser, so it was answering for every web
+    # link on the machine.  Point both routes at the same script instead.
+    xdg = {
+      desktopEntries.browse = {
+        name = "Browse";
+        genericName = "Web Browser";
+        exec = "${pkgs.launcher}/bin/browse %U";
+        terminal = false;
+        categories = ["Network" "WebBrowser"];
+        mimeType = [
+          "text/html"
+          "x-scheme-handler/http"
+          "x-scheme-handler/https"
+        ];
+      };
+
+      mimeApps = {
+        enable = true;
+        defaultApplications = {
+          "text/html" = "browse.desktop";
+          "x-scheme-handler/http" = "browse.desktop";
+          "x-scheme-handler/https" = "browse.desktop";
+        };
+      };
+    };
   };
 }

--- a/pkgs/launcher/scripts/browse.nix
+++ b/pkgs/launcher/scripts/browse.nix
@@ -37,11 +37,15 @@ writeShellScriptBin "browse" ''
     shift
   done
 
+  # Quoted, because this is the registered http/https handler now: a file://
+  # URL for a path with a space arrives as one argument and would otherwise
+  # split into two.  The :+ keeps an empty target from becoming an empty
+  # argument, which is what opens the browser on its homepage.
   case $browser in
-    brave) exec $brave $target >/dev/null 2>&1 ;;
-    chromium) exec $chromium $target >/dev/null 2>&1 ;;
-    tor-browser) exec $tor $target >/dev/null 2>&1 ;;
-    chrome) exec $chrome $target >/dev/null 2>&1 ;;
-    firefox) exec $firefox $target >/dev/null 2>&1 ;;
+    brave) exec $brave ''${target:+"$target"} >/dev/null 2>&1 ;;
+    chromium) exec $chromium ''${target:+"$target"} >/dev/null 2>&1 ;;
+    tor-browser) exec $tor ''${target:+"$target"} >/dev/null 2>&1 ;;
+    chrome) exec $chrome ''${target:+"$target"} >/dev/null 2>&1 ;;
+    firefox) exec $firefox ''${target:+"$target"} >/dev/null 2>&1 ;;
   esac
 ''


### PR DESCRIPTION
Fixes the ChatGPT sign-in failure, which turned out not to be a packaging problem with the app at all.

## What was happening

Clicking **Sign in** did nothing — a flash of "Continue to sign in on your browser", then back to the sign-in screen, and "A ChatGPT login is already in progress" on a retry.

`strace -f -e trace=execve` on the app while clicking:

```
execve(".../coreutils/bin/env", [..., ".../chatgpt-desktop-26.820.71523/bin/chatgpt",
                                 "https://chatgpt.com/codex/deskto"...])
execve(".../chatgpt-desktop-26.820.71523/bin/chatgpt", [..., "https://chatgpt.com/codex/deskto"...])
```

The app resolves the login URL through the xdg handler for `https` and execs that `.desktop`'s `Exec` line — which is itself. The second instance finds the first through Chromium's `ProcessSingleton`, prints `Opening in existing browser session.`, and exits. No browser is launched, and the first login stays pending forever.

It answered for `https` because the `.deb` declares:

```
MimeType=x-scheme-handler/codex;x-scheme-handler/http;x-scheme-handler/https;text/csv;...
```

and this machine has no default browser registered:

```
$ xdg-settings get default-web-browser
                     # empty
$ grep -rn x-scheme-handler/http ~/.config/mimeapps.list
                     # nothing
```

With no default set, the only claimant wins. So this was never only a login bug — *any* app opening a web link here reached the ChatGPT app.

## What this changes

**The app stops claiming the two web schemes.** It keeps `x-scheme-handler/codex`, which is genuinely its own, and the file-type associations. `--replace-fail`, so a future `.deb` that stops shipping that exact list fails the build rather than silently going back to answering for the web.

**A default gets registered**, because once ChatGPT stops claiming `https` nothing else here does. `$BROWSER` is already the launcher's `browse` script, but `$BROWSER` only reaches things that read it, which desktop apps mostly don't. The same script now gets a `.desktop` and is set as the default for `http`, `https` and `text/html`, so both routes land in one place and `browse`'s own `--browser` default stays the single choice of browser.

## Ruled out along the way

- **`LD_LIBRARY_PATH` leaking into children** — real, and fixed in #19, but not this. Running the bundled `resources/codex login` by hand opens a browser with the app's `LD_LIBRARY_PATH` set and without it alike.
- **`xdg-open`** — never invoked. A logging shim ahead of the app on `PATH` was never called.
- **The D-Bus portal** — `dbus-monitor` during a click shows no `OpenURI` call. The only portal traffic is `Settings.ReadAll` for theme detection, which fails `UnknownMethod` on every GTK app here and is unrelated.

## Verification

CI covers evaluation and the package build. The behavioural check needs hardware: after deploying, `xdg-settings get default-web-browser` should report `browse.desktop`, and clicking **Sign in** should open a browser.

## Noticed, not fixed here

`xdg.portal.extraPortals` at `config/modules/ui/sway/default.nix:205` installs nothing. home-manager's portal module adds backends via `home.packages` at normal priority, and this repo's `lib.mkForce` idiom on `home.packages` discards them — which is why only `xdg-desktop-portal-wlr` (hand-added to a `mkForce` list) is on the bus and `gtk` is not. Unrelated to this bug, but it means `FileChooser` and `OpenURI` have no implementation on this machine. Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VHH9pj1eDhtmmfNwE4ZnY

---
_Generated by [Claude Code](https://claude.ai/code/session_013VHH9pj1eDhtmmfNwE4ZnY)_