### PR TITLE
[xdg-portal] Actually install the portal backends

### DIFF
--- a/config/modules/ui/sway/default.nix
+++ b/config/modules/ui/sway/default.nix
@@ -201,9 +201,16 @@ in {
       '';
     };
 
+    # wlr implements Screenshot and ScreenCast; everything else a portal is
+    # asked for comes from gtk, which ui/xdg-portal contributes.  Naming the
+    # package in `home.packages` above as well is what actually installs it --
+    # see the comment there for why `extraPortals` on its own doesn't.
+    #
+    # `configPackages` goes the same way and is left off deliberately: the
+    # config below is set explicitly rather than read out of sway's own
+    # portals.conf, so nothing depends on that package reaching the profile.
     xdg.portal = {
-      extraPortals = [pkgs.xdg-desktop-portal-wlr pkgs.xdg-desktop-portal-gtk];
-      configPackages = [pkgs.sway];
+      extraPortals = [pkgs.xdg-desktop-portal-wlr];
       config.sway.default = ["wlr" "gtk"];
     };
   };

--- a/config/modules/ui/xdg-portal/default.nix
+++ b/config/modules/ui/xdg-portal/default.nix
@@ -3,10 +3,39 @@
   lib,
   ...
 }: {
-  environment.pathsToLink = ["/share/xdg-desktop-portal" "/share/applications"];
+  # Neither is a NixOS default: /share/xdg-desktop-portal carries the .portal
+  # files the frontend reads to discover backends, /share/applications the
+  # desktop entries.  With `useUserPackages` the per-user profile is filtered
+  # by this list, so a backend package that isn't linked here is invisible.
+  # (/share/dbus-1, which carries the service files the frontend activates a
+  # backend by name through, is already linked by `services.dbus`; /share/
+  # systemd, which carries the units those service files name, is a default.)
+  environment.pathsToLink = [
+    "/share/applications"
+    "/share/xdg-desktop-portal"
+  ];
 
   primary-user.home-manager = {
-    home.packages = lib.mkForce [pkgs.xdg-desktop-portal];
-    xdg.portal.enable = true;
+    # home-manager installs the frontend and everything in `extraPortals`
+    # through `home.packages`, at the normal priority this repo's `lib.mkForce`
+    # on that list discards -- so `extraPortals` alone installs nothing, and
+    # each backend has to be named here too.  Setting it is still required
+    # (home-manager asserts on an empty list) and is what the generated
+    # portals.conf is checked against.
+    home.packages = lib.mkForce [
+      pkgs.xdg-desktop-portal
+      pkgs.xdg-desktop-portal-gtk
+    ];
+
+    # gtk is the backend that implements FileChooser, AppChooser, Settings,
+    # Print and most of the rest.  wlr, added by the sway module, implements
+    # only Screenshot and ScreenCast, so without this the interfaces every GTK
+    # app asks for on startup have no implementation at all -- including the
+    # AppChooser that the frontend's own OpenURI falls back to when there is no
+    # default handler for a URL.
+    xdg.portal = {
+      enable = true;
+      extraPortals = [pkgs.xdg-desktop-portal-gtk];
+    };
   };
 }


### PR DESCRIPTION
`xdg.portal.extraPortals` has been installing nothing on this machine.

## The bug

home-manager's portal module installs the frontend and every entry of `extraPortals` through `home.packages` (`modules/misc/xdg-portal.nix:172` at the pinned rev):

```nix
home = {
  packages = packages ++ cfg.configPackages;
```

That's a normal-priority definition, and this repo's `lib.mkForce` on `home.packages` — the idiom documented in `config/modules/data/session-vars/home.nix:1-15`, used in ~18 modules — discards every normal-priority contribution. So `extraPortals = [wlr gtk]` at `config/modules/ui/sway/default.nix:205` installed neither.

The only reason anything works today is that the sway module happens to name `pkgs.xdg-desktop-portal-wlr` by hand in its own `mkForce` list (`sway/default.nix:24`). Confirmed on the session bus:

```
$ busctl --user list | grep -i portal
org.freedesktop.impl.portal.desktop.wlr    3864  ...
org.freedesktop.portal.Desktop             3838  ...
```

No `gtk`. And `wlr` implements only Screenshot and ScreenCast, so FileChooser, AppChooser, Settings, Print and the rest have had **no implementation at all** — including the AppChooser the frontend's own `OpenURI` falls back to when a URL has no default handler. That's what these are, logged by every GTK app on startup:

```
org.freedesktop.DBus.Error.InvalidArgs: No such interface "org.freedesktop.portal.FileChooser"
org.freedesktop.DBus.Error.UnknownMethod: No such interface "org.freedesktop.portal.Settings"
```

## The fix

**gtk gets named in a `mkForce` list**, the same way wlr already was, with a comment at both sites explaining why setting the option alone isn't enough. `extraPortals` stays set — home-manager asserts on an empty list, and it's what the generated `portals.conf` is validated against — but the package list is what installs.

Naming the package is the whole fix. Every other path a backend needs is already in place:

- `/share/dbus-1`, which carries the service file the frontend activates the backend by name through, comes from `nixos/modules/services/system/dbus.nix:123-126` (this repo enables `services.dbus`).
- `/share/systemd`, which carries the unit that service file names, is a `pathsToLink` default (`nixos/modules/config/system-path.nix:203`), inherited by the per-user profile (`users-groups.nix:990-996`) and reached via `XDG_DATA_DIRS`.

That second one is demonstrated by the frontend itself: `xdg-desktop-portal` also carries `SystemdService=`, has no `[Install]` section and no socket unit, is in no `systemd.packages` anywhere in this config, and is running today — visible in the `busctl` output above. The profile route is the only way it can be starting.

**sway's `configPackages` comes off.** It goes the same way as `extraPortals`, and the config it would have supplied is set explicitly on the next line, so nothing depended on that package reaching the profile.

## Corrected from earlier revisions of this PR

Two claims I made and then withdrew, recorded so the history reads straight:

- An earlier revision added `/share/dbus-1` to `environment.pathsToLink`, claiming the service files were being dropped. Wrong — `services.dbus` already contributes it. Removed.
- A later revision then claimed backends install units to `$out/lib/systemd/user`, outside systemd's search path, and added `systemd.packages` to compensate. Also wrong — `move-systemd-user-units.sh` is a default stdenv fixup hook (`pkgs/stdenv/generic/default.nix:81`) that relocates them to `$out/share/systemd/user`, and `/share/systemd` is a `pathsToLink` default. That made the `systemd.packages` line redundant; removed.

## Relationship to #21

Found while diagnosing the ChatGPT sign-in bug, but **not** its cause — `dbus-monitor` during a sign-in click shows no `OpenURI` call at all. Independent bug, independent fix.

## Verification

CI covers evaluation. The behavioural check needs hardware — after deploying:

```
busctl --user list | grep -i portal
```

should now show `org.freedesktop.impl.portal.desktop.gtk` alongside `wlr`, and the `No such interface` errors should stop appearing in app logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VHH9pj1eDhtmmfNwE4ZnY