### PR TITLE
launcher: reuse the running Claude instead of starting another copy

### DIFF
--- a/config/modules/ui/launcher/apps/claude.nix
+++ b/config/modules/ui/launcher/apps/claude.nix
@@ -1,0 +1,201 @@
+{
+  writeShellScript,
+  claude-desktop,
+  coreutils,
+  jq,
+  notify-send,
+  sway,
+  systemd,
+}:
+# Claude Desktop closes to the tray rather than quitting, and launching it again
+# starts a second copy instead of coming back to the one that's already there.
+# So don't launch it when it's already running: raise what's running instead.
+#
+# Two ways to raise it, because a closed window is gone from sway's tree
+# entirely -- it isn't hidden or minimized, the surface is destroyed -- and
+# there is nothing left to focus.  With a window still open we focus it; with
+# only the tray icon left we click that icon's own "open" entry over D-Bus,
+# which is the same path a mouse click through waybar takes.
+writeShellScript "claude" ''
+  busctl=${systemd}/bin/busctl
+  claudeDesktop=${claude-desktop}/bin/claude-desktop
+  date=${coreutils}/bin/date
+  jq=${jq}/bin/jq
+  notifySend=${notify-send}/bin/notify-send
+  sleep=${coreutils}/bin/sleep
+  swaymsg=${sway}/bin/swaymsg
+  test=${coreutils}/bin/test
+
+  # Every container lists its children in `focus` most-recently-used first, so
+  # descending that rather than `nodes` walks the windows in MRU order and the
+  # first match is the Claude window last looked at.  Nothing in the scratchpad
+  # is reachable that way -- sway builds `focus` from the seat's focus stack,
+  # which drops containers with no workspace -- so the plain scan follows as a
+  # fallback.  Repeats past that point cost nothing: the loop stops at the
+  # first Claude window either list turns up.
+  windows='
+    def leaves:
+      (.focus // []) as $order
+      | ((.nodes // []) + (.floating_nodes // [])) as $children
+      | if ($children | length) == 0
+        then .
+        else ($order[] as $id | $children[] | select(.id == $id) | leaves)
+        end;
+    (leaves | select(.pid)), (.. | objects | select(.pid and .id))
+    | "\(.pid):\(.id)"
+  '
+
+  # Pick the menu entry that reopens the window.  The label is the app's to
+  # choose and we don't get to see it from here, so drop everything that is
+  # definitely something else first -- quitting and hiding most of all -- and
+  # only then take the best of what's left, most specific first: a plain
+  # "show", then an "open" that names only the app, then one naming it at all,
+  # then any "open", then anything naming Claude.  Without the tiers a later
+  # release adding "Open Cowork" above "Show Claude" would win on menu order
+  # alone.
+  #
+  # A wrong guess is worse than no guess, because clicking is all we can see:
+  # the call succeeds when the app accepts the event, not when a window
+  # appears, so a mis-click leaves nothing raised and nothing launched either.
+  openEntry='
+    def entries:
+      .. | objects | select(.type == "(ia{sv}av)") | .data
+      | select(((.[1].visible.data) != false) and ((.[1].enabled.data) != false))
+      | select(((.[1].type.data) // "standard") != "separator")
+      | select(((.[1]["children-display"].data) // "") != "submenu")
+      | {id: .[0], label: ((.[1].label.data // "") | gsub("[_&]"; "") | ascii_downcase)};
+    [entries]
+    | map(select(.label | test("quit|exit|hide|close|sign ?out|log ?out|setting|preference|about|update|check for|developer|dev ?tools|console") | not))
+    | (map(select(.label | test("show|restore|reopen")))
+      + map(select(.label | test("^open( the)?( main)?( claude)?( app| window)?$")))
+      + map(select((.label | test("open")) and (.label | test("claude"))))
+      + map(select(.label | test("open")))
+      + map(select(.label | test("claude"))))
+    | first.id // empty
+  '
+
+  # The window belongs to the process that owns the surface, and that is the
+  # one to recognize here -- not `app_id`, which is whatever the bundled
+  # Electron build sets and can change with a release.  Match argv[0]'s
+  # basename rather than the store path, so an instance still running from
+  # before a switch is recognized too.  (Redirect stderr before opening the
+  # file: the other order reports a vanished pid on the still-open stderr.)
+  isClaude() {
+    local argv0
+    read -r -d "" argv0 2>/dev/null < "/proc/$1/cmdline" || return 1
+    case ''${argv0##*/} in
+      claude-desktop) return 0 ;;
+      *) return 1 ;;
+    esac
+  }
+
+  isRunning() {
+    local cmdline pid
+    for cmdline in /proc/[0-9]*/cmdline
+    do
+      pid="''${cmdline#/proc/}"
+      isClaude "''${pid%/cmdline}" && return 0
+    done
+    return 1
+  }
+
+  # No guard on $SWAYSOCK: with no sway reachable this yields no windows,
+  # which is the launch path anyway.
+  focusWindow() {
+    local window
+    for window in $($swaymsg -t get_tree 2>/dev/null | $jq -r "$windows")
+    do
+      if isClaude "''${window%%:*}"
+      then
+        $swaymsg "[con_id=''${window##*:}] focus" >/dev/null && return 0
+      fi
+    done
+    return 1
+  }
+
+  # Walk the tray items waybar knows about, find the one owned by Claude, and
+  # click the entry that reopens the window.  The spec's own primary action,
+  # `Activate`, would be the obvious thing to call instead, but Electron puts
+  # the icon up through libayatana-appindicator, which serves the menu and
+  # answers `Activate` with an error -- so it's only worth a try afterwards.
+  openFromTray() {
+    local item service path pid menu entry
+    for item in $($busctl --user --json=short get-property \
+      org.kde.StatusNotifierWatcher /StatusNotifierWatcher \
+      org.kde.StatusNotifierWatcher RegisteredStatusNotifierItems 2>/dev/null \
+      | $jq -r '.data[]?')
+    do
+      service="''${item%%/*}"
+      case $item in
+        */*) path="/''${item#*/}" ;;
+        *) path=/StatusNotifierItem ;;
+      esac
+
+      pid=$($busctl --user --json=short call \
+        org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus \
+        GetConnectionUnixProcessID s "$service" 2>/dev/null \
+        | $jq -r '.data[0]? // empty')
+      $test "$pid" || continue
+      isClaude "$pid" || continue
+
+      menu=$($busctl --user --json=short get-property "$service" "$path" \
+        org.kde.StatusNotifierItem Menu 2>/dev/null | $jq -r '.data? // empty')
+
+      if $test "$menu"
+      then
+        # Menus are commonly filled in only when they're about to be shown.
+        $busctl --user call "$service" "$menu" \
+          com.canonical.dbusmenu AboutToShow i 0 >/dev/null 2>&1
+
+        # Depth 1, so only the entries a click can reach: a submenu's children
+        # may not be filled in until its own AboutToShow, which we never send.
+        # No property names, which the spec reads as all of them -- asking for
+        # `label` alone would leave the filters above with nothing to test.
+        entry=$($busctl --user --json=short call "$service" "$menu" \
+          com.canonical.dbusmenu GetLayout iias -- 0 1 0 2>/dev/null \
+          | $jq -r "$openEntry")
+
+        if $test "$entry" && $busctl --user call "$service" "$menu" \
+          com.canonical.dbusmenu Event isvu -- \
+          "$entry" clicked s "" "$($date +%s)" >/dev/null 2>&1
+        then
+          return 0
+        fi
+      fi
+
+      $busctl --user call "$service" "$path" \
+        org.kde.StatusNotifierItem Activate ii 0 0 >/dev/null 2>&1 && return 0
+    done
+    return 1
+  }
+
+  # Arguments are a deep link for the running instance to open, which only
+  # launching can hand over, so a bare invocation is the only one answered
+  # with a raise.
+  if $test $# -eq 0
+  then
+    focusWindow && exit
+    openFromTray && exit
+
+    # A copy still starting up has no window and no tray icon yet, which is
+    # what a double-tapped launcher key looks like from here.  Wait for it
+    # rather than answering with the second copy this exists to avoid --
+    # polling the window, since a copy that is starting maps one rather than
+    # stopping at the tray, and leaving as soon as it does.
+    if isRunning
+    then
+      for _ in 1 2 3 4 5 6 7 8
+      do
+        $sleep 0.5
+        focusWindow && exit
+      done
+      openFromTray && exit
+
+      # Launching is still better than doing nothing, but say so.
+      $notifySend -i claude-desktop "Claude is already running" \
+        "Couldn't reach its window or tray icon -- starting another copy."
+    fi
+  fi
+
+  exec $claudeDesktop "$@"
+''

--- a/config/modules/ui/launcher/default.nix
+++ b/config/modules/ui/launcher/default.nix
@@ -57,7 +57,7 @@ in {
           chatgpt = "${pkgs.chatgpt-desktop}/bin/chatgpt";
           chrome = pkgs.writeShellScript "chrome" "${pkgs.launcher}/bin/browse --browser chrome $*";
           chromium = pkgs.writeShellScript "chromium" "${pkgs.launcher}/bin/browse --browser chromium $*";
-          claude = "${pkgs.claude-desktop}/bin/claude-desktop";
+          claude = pkgs.callPackage ./apps/claude.nix {};
           credit-cards = mkWebApp "credit-cards" "https://docs.google.com/spreadsheets/d/1Y8xind-5nMe9bezMFmk__CQdkSBd7FPupt1NkdKDLUE?authuser=connor@prussin.net";
           crux = mkTerminalApp "crux" "${pkgs.openssh}/bin/ssh -t crux load-session";
           cups = mkWebApp "cups" "http://localhost:631";


### PR DESCRIPTION
Claude Desktop closes to the tray rather than quitting, and launching it again starts a second copy instead of coming back to the one already there. The launcher's `claude` entry now points at a wrapper that raises what's running.

A closed window is gone from sway's tree entirely — the surface is destroyed, not hidden — so there are two cases:

- **Window still open** → `swaymsg [con_id=…] focus`. Matched by the owning process's argv[0] basename (`/proc/<pid>/cmdline`) rather than `app_id`, which the bundled Electron build can change between releases, and walked in sway's MRU order (descending each container's `focus`, with a plain scan appended so scratchpad windows stay reachable).
- **Only the tray icon left** → find the StatusNotifierItem whose bus connection belongs to a `claude-desktop` process, read its `Menu`, and click the entry that reopens the window — the same path a mouse click through waybar takes. `Activate`, the spec's primary action, is tried only afterwards: Electron puts the icon up through libayatana-appindicator, which serves the menu and answers `Activate` with an error.

Arguments are a deep link only a launch can hand over, so they keep the old path. A copy still starting up has neither window nor tray icon yet — what a double-tapped launcher key looks like from here — so that case polls for the window and only then falls back to `notify-send` and a launch, rather than leaving the launcher looking broken.

### Picking the menu entry

The one part that depends on a label we don't control. A wrong click is worse than none, since the D-Bus call succeeds when the app accepts the event rather than when a window appears — so it drops anything definitely something else first (quit, hide, close, settings, about, updates, devtools), then takes the best of what's left, most specific first: a plain "show"/"restore"/"reopen"; an "open" naming only the app; an "open" naming Claude; any "open"; anything naming Claude. Disabled, hidden, separator and submenu-parent entries are filtered out. If nothing qualifies it declines and launches instead of guessing.

### Testing

The D-Bus path was exercised for real, not reasoned about: a fake StatusNotifierWatcher + StatusNotifierItem + `com.canonical.dbusmenu` service (shaped like libayatana-appindicator — including its `Activate` error, and honouring `propertyNames` and `recursionDepth`) served over `dbus-run-session`, with the rendered script driven against it and stub `swaymsg`/`notify-send`/`claude-desktop` binaries.

| scenario | result |
|---|---|
| tray icon only, no window | clicks the open entry, no launch |
| window open | focuses it, tray untouched |
| invoked with a deep link | launches, hand-off preserved |
| nothing running | launches |
| running, but nothing answers | polls, notifies, then launches |

Menu-entry selection, end to end against that service:

| menu | clicked |
|---|---|
| `Open Cowork`, `Show Claude`, `Quit` | Show Claude |
| `Open Cowork`, `Open Claude Desktop` | Open Claude Desktop |
| `Open Developer Tools`, `Show Claude` | Show Claude |
| `Open Recent` (submenu), `Show Claude` | Show Claude |
| `Open Settings`, `Show Window` | Show Window |
| `_Show Claude`, `Quit` | Show Claude |
| separator, `Open Claude` | Open Claude |
| `Hide Claude` / `Show/Hide Claude` + `Quit Claude` | none → launch |
| `Quit Claude` only, empty menu | none → launch |
| `Show Claude` disabled or invisible | none → launch |

Fast paths timed to confirm the start-up poll costs them nothing: window present 0.47s, tray-only 0.50s, args 0.34s, nothing running 0.03s.

### Still worth checking on the machine

Which entry the tray menu actually offers is inferred from its label, and Claude Desktop's real menu was never visible from where this was written. If a tray-only `claude` launches a second copy and notifies instead of raising, the labels are the fix — `busctl --user --json=short get-property org.kde.StatusNotifierWatcher /StatusNotifierWatcher org.kde.StatusNotifierWatcher RegisteredStatusNotifierItems`, then `GetLayout` on that item's `Menu` path.