### PR TITLE
[printers] Wait for wireguard before ensuring the printer

### DIFF
--- a/config/modules/system/devices/printers/default.nix
+++ b/config/modules/system/devices/printers/default.nix
@@ -12,4 +12,28 @@ _: {
       }
     ];
   };
+
+  # `-m everywhere` fetches the queue's capabilities over IPP, which only works
+  # once the wireguard tunnel carries traffic -- and on a laptop that's a while
+  # after the tunnel's units finish, so retry too.
+  systemd.services.ensure-printers = {
+    wants = ["wireguard-prussinnet.target"];
+    after = ["wireguard-prussinnet.target"];
+    serviceConfig = {
+      Restart = "on-failure";
+      RestartSec = "15s";
+    };
+
+    # Caps total attempts rather than attempts per window: a failure against the
+    # tunnel's black-holed nameservers takes long enough to reset a finite
+    # window instead of tripping it.  Not `TimeoutStartSec` -- `-m everywhere`
+    # is fetched by cupsd in a thread that outlives a killed lpadmin, and a
+    # stale one failing after a later attempt succeeded marks the new queue
+    # temporary, so cupsd deletes it.  Hitting the cap means a start by hand
+    # needs `systemctl reset-failed` first.
+    unitConfig = {
+      StartLimitIntervalSec = "infinity";
+      StartLimitBurst = 20;
+    };
+  };
 }


### PR DESCRIPTION
## Problem

`ensure-printers` fails on every boot of lyra.

- The unit runs `lpadmin -p circinus -v ipp://circinus.internal.prussin.net/... -m everywhere -E`.
- `-m everywhere` makes cupsd fetch the queue's capabilities from the server over IPP, so it needs to resolve *and* reach the host.
- `circinus.internal.prussin.net` only resolves via crux's nameserver (installed by the tunnel's `postSetup` resolvconf) and CUPS on crux only listens on the wireguard addresses behind an `@IF(prussinnet)` firewall rule.
- Upstream's unit is ordered only `after = [ "cups.service" ]`, so it races the tunnel and exits non-zero.
- Nothing persists `/var/lib/cups` across a boot, so the failure leaves the machine with no printer until the unit is started by hand.

## Fix

- Order `ensure-printers` after `wireguard-prussinnet.target`.
- Retry on failure every 15s, capped at 20 attempts. Ordering alone isn't sufficient on a laptop: the peer unit is `oneshot` and completes as soon as `wg set` returns, well before wifi has associated and the handshake has landed — so the retry is what actually makes this work.

### Why `StartLimitIntervalSec = "infinity"`

It caps *total* attempts. A finite window can't bound this: systemd resets the window whenever a start arrives after it has elapsed, and a lookup against the tunnel's black-holed nameservers takes tens of seconds, so the burst would never trip.

Bounding the attempt with `TimeoutStartSec` instead would introduce a worse bug. In CUPS 2.4.19 `-m everywhere` is not fetched by `lpadmin` — cupsd does it in a detached thread (`create_local_bg_thread`, 30s connect timeout) that outlives a SIGTERMed `lpadmin`. Every failure path there sets `state_time = 0; temporary = 1`, the success path never clears `temporary`, and `cupsdDeleteTemporaryPrinters(0)` reaps on `state_time < now - 300`. So a stale thread failing *after* a later attempt succeeded deletes the queue that just got created — no printer, green unit.

The cost is that once the cap is spent, a start by hand needs `systemctl reset-failed` first. That's noted in the comment.

Booting away from any network still ends in a failed unit, as before — no regression there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dm9eWzFzp6E27QH53TJrfs

---
_Generated by [Claude Code](https://claude.ai/code)_