### PR TITLE
[crux] Fix the private server's unit

### DIFF
--- a/config/machines/crux/private.nix
+++ b/config/machines/crux/private.nix
@@ -45,21 +45,62 @@ in {
 
   networking.firewall.interfaces.prussinnet.allowedTCPPorts = [42042];
 
-  primary-user.home-manager.systemd.user.services.private = {
-    Unit = {
-      Description = "Private";
-    };
+  # A system unit rather than a home-manager user unit.  The user unit couldn't
+  # express what it needed: `Requires=`/`After=` sat in `[Install]`, a section
+  # where systemd knows no such keys and drops them, and a user unit can't order
+  # itself against a system unit like `import-tank` even from `[Unit]`.  Nor
+  # would it stay up -- without lingering the user manager only exists between
+  # login and logout, so `default.target` never came up at boot and every unit
+  # under it died with the last session.
+  systemd.services.private = {
+    description = "Private";
+    wantedBy = ["multi-user.target"];
 
-    Service = {
+    # `/` is a tmpfs and `/home` comes from tank, so the checkout doesn't exist
+    # until `import-tank` has run `zfs mount -a`.  `requires` propagates that
+    # unit's stop to this one; `after` is what orders this unit's stop ahead of
+    # the `zpool export` in its `preStop`, which nothing released the pool for
+    # before.
+    #
+    # `network-online.target` isn't for the server, which needs no address to
+    # exist before it binds -- nginx doesn't wait on it either.  It's for `nix
+    # develop`, which re-evaluates the flake on every start and, after the
+    # weekly `nix.gc`, may have to refetch to do it.
+    requires = ["import-tank.service"];
+    after = [
+      "import-tank.service"
+      "network-online.target"
+    ];
+    wants = ["network-online.target"];
+
+    # Nix still shells out to `git` for some flake refs, and it does that while
+    # evaluating -- with this PATH, before the devShell exists.  (`nix develop`
+    # then prepends the devShell's PATH rather than replacing it, so this stays
+    # reachable as the tail.)
+    path = [pkgs.git];
+
+    serviceConfig = {
       Type = "simple";
-      ExecStart = "/bin/sh -c 'cd ~/Private && ${pkgs.nix}/bin/nix develop --command cli start-prod'";
-      Restart = "on-failure";
-    };
+      User = config.primary-user.name;
 
-    Install = {
-      WantedBy = ["default.target"];
-      Requires = ["import-tank.service"];
-      After = ["import-tank.service"];
+      # `WorkingDirectory` rather than the old `/bin/sh -c 'cd ~/Private && ...'`.
+      # Not for supervision: NixOS's `/bin/sh` is bash, which execs the last
+      # command of a `-c` list, so `nix` was already the main process either way.
+      # It's that the directory is declared where `systemctl show` reports it,
+      # instead of buried in a string only a shell can read.
+      WorkingDirectory = "${config.primary-user.home}/Private";
+      ExecStart = "${pkgs.nix}/bin/nix develop --command cli start-prod";
+
+      # A server that stops serving is a failure however it exited, so
+      # `on-failure` was wrong: a clean exit left the port dead until someone
+      # noticed.  `RestartSec` is the other half of it -- at the 100ms default,
+      # five restarts fit inside the limiter's 10s window and systemd then
+      # refuses to start the unit at all until `systemctl reset-failed`.  Spaced
+      # 10s apart the limiter can't be reached, so there's nothing to disable.
+      # Nothing surfaces as a `failed` unit either -- a dependency failure fails
+      # the start job, not the unit -- so an outage shows up in the journal.
+      Restart = "always";
+      RestartSec = "10s";
     };
   };
 }


### PR DESCRIPTION
Debugging why `nix develop --command cli start-prod` is solid in the foreground but flaps under systemd. Three defects, all in the unit:

**Ordering against `import-tank` never existed.** `Requires=`/`After=` were in `[Install]`, where systemd knows no such keys and drops them with a warning. A home-manager *user* unit couldn't have expressed it from `[Unit]` either — a user manager has no `import-tank.service`, and `Requires=` on a nonexistent unit refuses the start. `/` is a tmpfs and `/home` comes off tank via `zfs mount -a`, so every boot raced the pool for `~/Private`.

**Nothing kept the user manager alive.** Lingering is off, so `user@1000.service` only exists between login and logout. `default.target` never came up at boot, and the server went down with the last session.

**The restart policy converted stumbles into outages.** `RestartSec` defaults to 100ms, so five restarts fit inside the limiter's 10s window and systemd then refuses to start the unit at all until `systemctl reset-failed`. Same trap #24 removed from `ensure-printers`. And `on-failure` ignores a clean exit, which for a server is just a quieter outage.

## The change

Makes it a system unit, matching every other service on this machine (`syncthing`, `immich-server`, `matrix`, `nvr`, …):

- `requires`/`after` on `import-tank.service` now actually hold, and — new — the unit releases the pool ahead of `preStop`'s `zpool export`, which nothing did before.
- `wantedBy = multi-user.target` starts it at boot with no login involved.
- `User` + `WorkingDirectory` replace the shell wrapper.
- `Restart = "always"`, `RestartSec = "10s"`: 10s spacing puts the default limiter out of reach, so no start-limit override is needed.

## What this buys you in monitoring: nothing

Worth stating plainly, because two review passes got it wrong before landing here. With `Restart=always` and the start limiter unreachable, **this unit has no path into a `failed` state at all.** A dependency failure finishes the *start job* with `JOB_DEPENDENCY` and leaves the unit `inactive (dead)` — it never appears in `systemctl --failed`. A `~/Private` that can never start just retries every 10s forever in `auto-restart`.

That is the accepted cost of never giving up on a server, and it is strictly better than the old behavior (which gave up permanently after five fast restarts). But the only evidence of an outage is the journal. If you want an alert, that's a separate change — `OnFailure=` has nothing to hang off here.

## Corrected during review

An earlier revision claimed the `/bin/sh -c 'cd ~/Private && …'` wrapper broke supervision (shell as MainPID) and that `~` resolved only by accident of `$HOME`. **Both were wrong**, and the commit message says so. NixOS's `/bin/sh` is bash, which execs the last command of a `-c` list — verified: `bash -c 'cd /tmp && sleep 4' &` yields a job whose PID *is* `sleep`, no shell remaining — so `nix` was already the main process. And bash's tilde expansion falls back to the passwd entry: `env -u HOME bash -c 'echo ~'` prints `/root`. Dropping the wrapper is still right, but only because `WorkingDirectory` is declarative and visible to `systemctl show`.

Also dropped after review: an explicit `startLimitIntervalSec = 0`. With `RestartSec = "10s"` the default 5-starts-per-10s limiter is already unreachable, so disabling it was a no-op.

## Ruled out

Memory pressure and the per-restart flake evaluation both looked like candidates and are not: the machine has 62GB and this workload doesn't approach it, and the re-evaluation is acceptable as-is.

Left alone deliberately: `Type = "simple"` reports the unit started before Next.js binds, so nginx 502s for the first few seconds of each start.

## Worth checking before deploying

- **The evidence gap.** Two of the three defects predict *"the server is absent"*, not *"it dies and restarts constantly"*. Chronic restarts imply the user manager **was** running — which a long-lived ssh/tmux session would do — leaving the restart policy as the defect that directly explains the symptom. `journalctl --user -u private -b` would settle which story is true. Nothing here has been observed on the box.
- **`SSH_AUTH_SOCK`.** A system unit gets `HOME`/`USER`/`LOGNAME`/`SHELL` from the user database and nothing else — no ssh agent, stdin on `/dev/null`. If the `~/Private` flake has a `git+ssh` input, the post-GC refetch runs `git fetch` with no agent and no way to prompt.
- **First deploy.** If a live login session is still running the old `~/.config/systemd/user/private.service`, it holds `:42042` and the new system unit will crash-loop until it's stopped.
- **`systemctl --user restart private` becomes `sudo systemctl restart private`.** `primary-user.sudo-cmds` whitelists only `journalctl -alf`, so that now prompts for a password.

## Testing

Untested on the box — no `nix` in this environment. CI is green, including `eval crux` (which instantiates the machine, so the new options typecheck) and `cli test format`.