### PR TITLE
[crux] Add the credit card offer adder, and ntfy to answer its code prompts

### DIFF
--- a/config/machines/crux/backup.nix
+++ b/config/machines/crux/backup.nix
@@ -49,7 +49,11 @@
 
     echo
     echo -e "\e[1;37mSending incremental data...\e[0m"
-    zfs send -R -X tank/Cache,tank/Data/cprussin/Private,tank/Data/cprussin/Scratch,tank/Data/frigate -I tank@external-backup-$LAST_SNAP_DATE tank@external-backup-$TODAY | zfs recv -Fdu tank-backup
+    # -X is opt-out, unlike the borg job's net.prussin:backup, so anything new
+    # under tank lands on the external disk by default.  offer-adder holds live
+    # bank session cookies, and restoring a stale copy earns a challenge on
+    # every account anyway, so replicating it is all cost.
+    zfs send -R -X tank/Cache,tank/Data/cprussin/Private,tank/Data/cprussin/Scratch,tank/Data/frigate,tank/persisted-state/offer-adder -I tank@external-backup-$LAST_SNAP_DATE tank@external-backup-$TODAY | zfs recv -Fdu tank-backup
 
     echo
     echo -e "\e[1;37mScrubbing tank-backup...\e[0m"

--- a/config/machines/crux/default.nix
+++ b/config/machines/crux/default.nix
@@ -13,7 +13,9 @@
     ./library.nix
     ./libvirtd.nix
     ./matrix.nix
+    ./ntfy.nix
     ./nvr.nix
+    ./offer-adder.nix
     ./photos.nix
     ./powerpanel.nix
     ./private.nix

--- a/config/machines/crux/dns.nix
+++ b/config/machines/crux/dns.nix
@@ -9,7 +9,7 @@
     lib.concatStringsSep "\n" (
       map
       (wgNet: ''
-        ${wgNet.crux.address} library.internal.prussin.net home-assistant.internal.prussin.net matrix.internal.prussin.net passwords.internal.prussin.net circinus.internal.prussin.net eyes.internal.prussin.net photos.internal.prussin.net private.internal.prussin.net
+        ${wgNet.crux.address} library.internal.prussin.net home-assistant.internal.prussin.net matrix.internal.prussin.net ntfy.internal.prussin.net passwords.internal.prussin.net circinus.internal.prussin.net eyes.internal.prussin.net photos.internal.prussin.net private.internal.prussin.net
         ${
           lib.concatStringsSep "\n" (
             lib.mapAttrsToList

--- a/config/machines/crux/ntfy.nix
+++ b/config/machines/crux/ntfy.nix
@@ -1,0 +1,113 @@
+# ntfy is the offer adder's escape hatch: when Amex or Chase insists on a
+# one-time code, the run pushes a notification here and waits for a phone to
+# publish the digits back. It is wireguard-only and its whole auth database --
+# users, ACLs and the service account's token -- is provisioned from pass at
+# start, so nothing about it is imperative.
+{
+  config,
+  pkgs,
+  ...
+}: let
+  passwords = pkgs.callPackage ../../../lib/passwords.nix {};
+  network = pkgs.callPackage ../../../lib/network.nix {};
+  host = "ntfy.internal.prussin.net";
+  # Loopback only: nginx terminates TLS for the phones, and the offer adder
+  # running on this same box talks to it directly, which keeps the internal CA
+  # out of bun's certificate store entirely.
+  listenAddress = "127.0.0.1:2586";
+in {
+  deployment.keys = {
+    ntfy-secrets = {
+      keyCommand =
+        passwords.getNtfySecrets "offers-*"
+        "Connor/Infrastructure/ntfy/offer-adder"
+        [
+          "Connor/Infrastructure/ntfy/connor"
+          "Shauna/Infrastructure/ntfy/shauna"
+        ];
+      destDir = "/secrets";
+    };
+
+    "${host}.crt" = {
+      inherit (config.users.users.nginx) group;
+      keyCommand = passwords.getFullPassword "Connor/Infrastructure/ssl/${host}/cert";
+      user = config.users.users.nginx.name;
+    };
+
+    "${host}.key" = {
+      inherit (config.users.users.nginx) group;
+      keyCommand = passwords.getFullPassword "Connor/Infrastructure/ssl/${host}/key";
+      user = config.users.users.nginx.name;
+    };
+  };
+
+  networking.firewall.interfaces.prussinnet.allowedTCPPorts = [80 443];
+
+  services = {
+    ntfy-sh = {
+      enable = true;
+      environmentFile = config.deployment.keys.ntfy-secrets.path;
+      settings = {
+        base-url = "https://${host}";
+        listen-http = listenAddress;
+        behind-proxy = true;
+        # Every topic is private; the ACLs in the environment file are the only
+        # way in.  The auth database is rebuilt from that file on every start,
+        # so its StateDirectory is deliberately left on the tmpfs root: nothing
+        # in it needs to survive a reboot except what the environment already
+        # carries.  The one consequence is that a token minted at runtime
+        # through /v1/account/token does not come back, so the phones should
+        # authenticate with their username and password.
+        auth-default-access = "deny-all";
+      };
+    };
+
+    nginx = {
+      enable = true;
+      recommendedTlsSettings = true;
+      recommendedOptimisation = true;
+      recommendedGzipSettings = true;
+      recommendedProxySettings = true;
+      virtualHosts."${host}" = {
+        listenAddresses = ["[${network.wireguard6.crux.address}]" "${network.wireguard4.crux.address}"];
+        sslCertificate = config.deployment.keys."${host}.crt".path;
+        sslCertificateKey = config.deployment.keys."${host}.key".path;
+        forceSSL = true;
+        http2 = true;
+        locations."/" = {
+          proxyPass = "http://${listenAddress}";
+          proxyWebsockets = true;
+          # Subscribers hold a stream open until something is published, so
+          # buffering it would defeat the point entirely.  The read timeout is
+          # only belt and braces -- ntfy keepalives every 45s, inside nginx's
+          # 60s default -- but it is set past the five minutes a run waits for
+          # a code, so a phone that misses a keepalive still holds the stream
+          # across a whole request.
+          extraConfig = ''
+            proxy_buffering off;
+            proxy_request_buffering off;
+            proxy_read_timeout 6m;
+          '';
+        };
+      };
+    };
+  };
+
+  systemd.services = {
+    ntfy-sh = {
+      after = ["ntfy-secrets-key.service"];
+      requires = ["ntfy-secrets-key.service"];
+    };
+
+    nginx = {
+      after = [
+        "${host}.crt-key.service"
+        "${host}.key-key.service"
+      ];
+      requires = [
+        "${host}.crt-key.service"
+        "${host}.key-key.service"
+      ];
+    };
+  };
+}

--- a/config/machines/crux/offer-adder.nix
+++ b/config/machines/crux/offer-adder.nix
@@ -1,0 +1,108 @@
+# Twice a day, walk both Amex and both Chase accounts and add every offer the
+# issuers are handing out. The bank logins live in pass and are assembled into
+# the one JSON document the service reads; systemd stages it in a tmpfs only
+# this unit can see, so nothing lands in the environment or in `systemctl show`.
+{
+  config,
+  pkgs,
+  ...
+}: let
+  passwords = pkgs.callPackage ../../../lib/passwords.nix {};
+in {
+  deployment.keys.offer-adder-credentials = {
+    keyCommand =
+      passwords.getOfferAdderCredentials "Connor/Infrastructure/ntfy/offer-adder"
+      {
+        connor-amex = "Connor/Financial/American Express";
+        connor-chase = "Connor/Financial/Chase";
+        shauna-amex = "Shauna/Financial/American Express";
+        shauna-chase = "Shauna/Financial/Chase";
+      };
+    # /run/keys is a tmpfs that colmena refills on deploy, so a reboot without
+    # an `upload-keys` would silently break every run until the next deploy.
+    destDir = "/secrets";
+  };
+
+  services.offer-adder = {
+    enable = true;
+    credentialFile = config.deployment.keys.offer-adder-credentials.path;
+    # colmena hands over the plaintext document; systemd still stages it in the
+    # per-unit tmpfs, it just has no TPM sealing to undo first.
+    sealed = false;
+    # A challenge that reaches nobody costs the account its run -- ntfy waits
+    # five minutes for a reply -- so fire when somebody is awake rather than at
+    # the small hours the module defaults to.
+    onCalendar = "*-*-* 09:17,19:17:00";
+    settings = {
+      # Every account is `["ntfy"]` because neither issuer offers
+      # authenticator-app enrollment: a challenge always ends up on a phone.
+      # `"totp"` is not a preference that falls through to the rung behind it
+      # -- the ladder resolves the secret up front and fails the account for
+      # the whole run when there is none -- so it goes in only for an account
+      # actually enrolled, alongside a `TOTP Secret` field in its pass entry.
+      ntfy = {
+        server = "http://${config.services.ntfy-sh.settings.listen-http}";
+        alertTopic = "offers-alerts";
+        replyTopic = "offers-codes";
+      };
+      accounts = [
+        {
+          id = "connor-amex";
+          label = "Connor · Amex";
+          issuer = "amex";
+          senderHints = ["americanexpress" "american express"];
+          codeSources = ["ntfy"];
+        }
+        {
+          id = "connor-chase";
+          label = "Connor · Chase";
+          issuer = "chase";
+          senderHints = ["chase.com" "chase"];
+          codeSources = ["ntfy"];
+        }
+        {
+          id = "shauna-amex";
+          label = "Shauna · Amex";
+          issuer = "amex";
+          senderHints = ["americanexpress" "american express"];
+          codeSources = ["ntfy"];
+        }
+        {
+          id = "shauna-chase";
+          label = "Shauna · Chase";
+          issuer = "chase";
+          senderHints = ["chase.com" "chase"];
+          codeSources = ["ntfy"];
+        }
+      ];
+    };
+  };
+
+  # The service's StateDirectory holds one Chromium profile per account, and
+  # those profiles are the whole reason the banks stop challenging every login.
+  # `/` here is a tmpfs, so they live on `tank/persisted-state/offer-adder`,
+  # created with `mountpoint=/var/lib/offer-adder` and mounted natively by
+  # `zfs mount -a` like the rest of crux's service state -- not declared in
+  # `fileSystems`, which is for the tank-fast datasets.  `StateDirectory`
+  # chowns the dataset root to the service user on each start, so nothing
+  # here has to.  It is excluded from `run-backup` in ./backup.nix, and the
+  # borg job is opt-in on `net.prussin:backup` -- a user property, so confirm
+  # no ancestor sets it (`zfs get -s local,inherited net.prussin:backup tank
+  # tank/persisted-state`) rather than assuming an unset child is enough.
+  systemd.services.offer-adder = {
+    # `import-tank` is what mounts that dataset; without it the timer's
+    # catch-up run at boot writes profiles to the tmpfs root, and the later
+    # `zfs mount -a` silently shadows what it wrote.  ntfy is only wanted:
+    # requiring it would refuse the whole unit on a systemd dependency error,
+    # where wanting it lets the run happen and report which accounts could not
+    # get a code and why -- and a run only needs ntfy for an account the bank
+    # actually challenges, which most runs are not.
+    after = [
+      "offer-adder-credentials-key.service"
+      "import-tank.service"
+      "ntfy-sh.service"
+    ];
+    requires = ["offer-adder-credentials-key.service" "import-tank.service"];
+    wants = ["ntfy-sh.service"];
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,29 @@
 {
   "nodes": {
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "credit-card-offer-adder",
+          "nixpkgs"
+        ],
+        "systems": "systems_2",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1784665499,
+        "narHash": "sha256-9BMxlTxCCDAeoNLtb1a/st7udtTIJep+wpUzquA29VU=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "0f2a1f0b6f42cebe3b149bf62d38754c5e0e9729",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
     "colmena": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -19,6 +43,26 @@
       "original": {
         "owner": "zhaofengli",
         "repo": "colmena",
+        "type": "github"
+      }
+    },
+    "credit-card-offer-adder": {
+      "inputs": {
+        "bun2nix": "bun2nix",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1788025654,
+        "narHash": "sha256-WxhiXEUTT23Dbkk8wdBZWA2KcHHFXe75xQRioXC7uP8=",
+        "owner": "cprussin",
+        "repo": "credit-card-offer-adder",
+        "rev": "110fd306cf663bf5072407b345ffdb280171790a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cprussin",
+        "repo": "credit-card-offer-adder",
         "type": "github"
       }
     },
@@ -54,6 +98,28 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "credit-card-offer-adder",
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -74,7 +140,7 @@
     },
     "flake-utils_2": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -92,14 +158,14 @@
     },
     "flake-utils_3": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -110,7 +176,7 @@
     },
     "flake-utils_4": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -128,7 +194,25 @@
     },
     "flake-utils_5": {
       "inputs": {
-        "systems": "systems_5"
+        "systems": "systems_6"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_6": {
+      "inputs": {
+        "systems": "systems_7"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -162,9 +246,9 @@
     },
     "gmail-new-mail-counter": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_4",
         "mkCli": "mkCli",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1720136256,
@@ -215,8 +299,8 @@
     },
     "mkCli": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_2"
+        "flake-utils": "flake-utils_5",
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1718314200,
@@ -234,8 +318,8 @@
     },
     "mkCli_2": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_4"
+        "flake-utils": "flake-utils_6",
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1722285416,
@@ -274,7 +358,7 @@
     },
     "nixos-hardware": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1787144466,
@@ -324,6 +408,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1718310279,
         "narHash": "sha256-OfRCrNPMLlElYIUAWIOGAvJ5XDT/WpOXj6Ymfttj6Lk=",
         "owner": "NixOS",
@@ -337,7 +437,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1719254875,
         "narHash": "sha256-ECni+IkwXjusHsm9Sexdtq8weAq/yUyt1TWIemXt3Ko=",
@@ -353,7 +453,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1718310279,
         "narHash": "sha256-OfRCrNPMLlElYIUAWIOGAvJ5XDT/WpOXj6Ymfttj6Lk=",
@@ -368,7 +468,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1767892417,
         "narHash": "sha256-8bW3q88CEg2u4hSP66Vf4lpbLonHz7hqDNBMcCY7E9U=",
@@ -381,7 +481,7 @@
         "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1787414105,
         "narHash": "sha256-WncT27+3BOkgTaJZLnCsf3LcYf9RXMuR9ONSN4rzQ7s=",
@@ -416,15 +516,16 @@
     "root": {
       "inputs": {
         "colmena": "colmena",
+        "credit-card-offer-adder": "credit-card-offer-adder",
         "dircolors-solarized": "dircolors-solarized",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils_3",
         "fzf-pass": "fzf-pass",
         "gmail-new-mail-counter": "gmail-new-mail-counter",
         "gpg-key": "gpg-key",
         "home-manager": "home-manager",
         "mkCli": "mkCli_2",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "notify-send": "notify-send",
         "zoom-frm": "zoom-frm"
@@ -463,16 +564,16 @@
     },
     "systems_2": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "lastModified": 1776166891,
+        "narHash": "sha256-bI8yrEGjrohR5hkQox7UrxDH7XqrYMwI8SL/LrJ1+S8=",
         "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "repo": "triplet",
+        "rev": "6de7bc09397911ce03636afbcf6118745ab2cda0",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default",
+        "repo": "triplet",
         "type": "github"
       }
     },
@@ -518,6 +619,58 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_6": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_7": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "credit-card-offer-adder",
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784369104,
+        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,10 @@
 
     colmena.url = "github:zhaofengli/colmena";
 
+    # Deliberately not `nixpkgs.follows`: it pins playwright to the exact
+    # chromium its own nixpkgs ships, and a mismatched pair refuses to launch.
+    credit-card-offer-adder.url = "github:cprussin/credit-card-offer-adder";
+
     dircolors-solarized = {
       url = "github:seebi/dircolors-solarized";
       flake = false;
@@ -44,6 +48,7 @@
     home-manager,
     nixos-hardware,
     colmena,
+    credit-card-offer-adder,
     ...
   } @ flake-inputs: let
     password-utils-overlay = final: _: {
@@ -130,6 +135,9 @@
 
       crux = mkMachine {
         targetHost = "crux";
+        extraModules = [
+          credit-card-offer-adder.nixosModules.default
+        ];
       };
     };
   in

--- a/lib/passwords.nix
+++ b/lib/passwords.nix
@@ -1,10 +1,14 @@
-{pkgs}: let
+{
+  pkgs,
+  lib,
+}: let
   pass = "${pkgs.pass}/bin/pass";
   head = "${pkgs.coreutils}/bin/head";
   base64 = "${pkgs.coreutils}/bin/base64";
   grep = "${pkgs.gnugrep}/bin/grep";
   sed = "${pkgs.gnused}/bin/sed";
   mkpasswd = "${pkgs.mkpasswd}/bin/mkpasswd";
+  jq = "${pkgs.jq}/bin/jq";
 
   getFullPassword = pkgs.writeShellScriptBin "getFullPassword" ''
     set -euo pipefail
@@ -56,6 +60,95 @@
     fi
   '';
 
+  # The offer adder wants one JSON document holding every bank login, so this
+  # walks `<account id> <pass path>` pairs and assembles it. Each entry's first
+  # line is the password; `Username` and the optional `TOTP Secret` are fields.
+  # Nothing secret is ever passed in argv -- `ps` is world-readable -- so the
+  # values reach jq through the environment instead.
+  getOfferAdderCredentials = pkgs.writeShellScriptBin "getOfferAdderCredentials" ''
+    set -euo pipefail
+    # A plain assignment, and ahead of the loop: `VAR="$(...)" prog` is the one
+    # construct `set -e` cannot see, so a lookup that fails in an assignment
+    # prefix would hand jq an empty token and exit 0.  Doing it first also
+    # fails a bad ntfy entry before any bank password is read.
+    ntfyToken="$(${getPasswordField}/bin/getPasswordField "$1" "Token")"
+    shift
+    # Assembled into a variable rather than straight to stdout: `jq -s` on the
+    # right of the pipe would otherwise emit a partial document before the
+    # non-zero status of a failed lookup could stop it.
+    document="$(
+      {
+        while [ "$#" -gt 0 ]; do
+          if [ "$#" -lt 2 ]; then
+            echo "getOfferAdderCredentials: account \"$1\" has no pass path" >&2
+            exit 1
+          fi
+          entry="$(${pass} show "$2")"
+          # `TOTP Secret` is absent on every account today -- neither issuer
+          # offers authenticator-app enrollment -- and the credentials schema
+          # makes it optional, so it is emitted only when present.  An absent
+          # `Username` is always a malformed entry, though, and `sed` would
+          # otherwise hand over an empty string that deploys clean and fails
+          # at the bank sign-in twelve hours later.
+          username="$(printf '%s\n' "$entry" | ${sed} -n 's/^Username: //p')"
+          if [ -z "$username" ]; then
+            echo "getOfferAdderCredentials: no Username field in \"$2\"" >&2
+            exit 1
+          fi
+          OFFER_ADDER_PASSWORD="$(printf '%s\n' "$entry" | ${head} -n 1)" \
+          OFFER_ADDER_USERNAME="$username" \
+          OFFER_ADDER_TOTP="$(printf '%s\n' "$entry" | ${sed} -n 's/^TOTP Secret: //p')" \
+            ${jq} -cn --arg id "$1" '{
+              key: $id,
+              value: (
+                {
+                  username: $ENV.OFFER_ADDER_USERNAME,
+                  password: $ENV.OFFER_ADDER_PASSWORD,
+                }
+                + (
+                  if $ENV.OFFER_ADDER_TOTP == "" then {}
+                  else {totpSecret: $ENV.OFFER_ADDER_TOTP}
+                  end
+                )
+              ),
+            }'
+          shift 2
+        done
+      } | OFFER_ADDER_NTFY_TOKEN="$ntfyToken" \
+        ${jq} -s '{ntfyToken: $ENV.OFFER_ADDER_NTFY_TOKEN, accounts: from_entries}'
+    )"
+    printf '%s\n' "$document"
+  '';
+
+  # ntfy provisions its users, their ACLs and their access tokens from the
+  # environment at startup, so the whole auth database is derivable from pass.
+  # Each entry's first line is the password and `Username` names the ntfy user;
+  # the first path is the service account, whose `Token` field the offer adder
+  # authenticates with. That field must be `ntfy token generate` output --
+  # `tk_` and 29 more characters -- because ntfy validates provisioned tokens
+  # at startup and refuses to serve at all when one is malformed.
+  getNtfySecrets = pkgs.writeShellScriptBin "getNtfySecrets" ''
+    set -euo pipefail
+    topic="$1"
+    servicePath="$2"
+    # Drop only the topic: the service account is a user like any other, it
+    # just also carries the token.
+    shift
+    users=""
+    access=""
+    for path in "$@"; do
+      username="$(${getPasswordField}/bin/getPasswordField "$path" "Username")"
+      hash="$(${pass} show "$path" | ${mkpasswd} -m bcrypt -R 10 -s)"
+      users="''${users:+$users,}$username:$hash:user"
+      access="''${access:+$access,}$username:$topic:rw"
+    done
+    # Single quotes: systemd reads them literally, and a bcrypt hash is full of
+    # dollar signs.
+    echo "NTFY_AUTH_USERS='$users'"
+    echo "NTFY_AUTH_ACCESS='$access'"
+    echo "NTFY_AUTH_TOKENS='$(${getPasswordField}/bin/getPasswordField "$servicePath" "Username"):$(${getPasswordField}/bin/getPasswordField "$servicePath" "Token")'"
+  '';
+
   getImmichSecrets = pkgs.writeShellScriptBin "getImmichSecrets" ''
     set -euo pipefail
     echo "DB_PASSWORD=$(${getPassword}/bin/getPassword "$1")"
@@ -80,6 +173,8 @@ in {
       getVaultwardenSecrets
       getGmailNewMailCounterEnvFile
       getImmichSecrets
+      getNtfySecrets
+      getOfferAdderCredentials
     ];
   };
   getPassword = name: ["getPassword" name];
@@ -97,4 +192,9 @@ in {
     );
   getGmailNewMailCounterEnvFile = name: ["getGmailNewMailCounterEnvFile" name];
   getImmichSecrets = db: ["getImmichSecrets" db];
+  getNtfySecrets = topic: servicePath: humanPaths:
+    ["getNtfySecrets" topic servicePath] ++ humanPaths;
+  getOfferAdderCredentials = ntfyPath: accounts:
+    ["getOfferAdderCredentials" ntfyPath]
+    ++ lib.concatLists (lib.mapAttrsToList (id: path: [id path]) accounts);
 }


### PR DESCRIPTION
Runs `credit-card-offer-adder` on crux twice a day across both Amex and both Chase accounts, plus the ntfy server its one-time-code ladder needs.

## Shape

| Piece | Where |
|---|---|
| `services.offer-adder` + its credentials key | `config/machines/crux/offer-adder.nix` |
| `services.ntfy-sh`, its nginx vhost, its auth key | `config/machines/crux/ntfy.nix` |
| `getOfferAdderCredentials`, `getNtfySecrets` | `lib/passwords.nix` |
| flake input (no `nixpkgs.follows`) + lock | `flake.nix`, `flake.lock` |
| `ntfy.internal.prussin.net` | `config/machines/crux/dns.nix` |
| profile dataset excluded from run-backup | `config/machines/crux/backup.nix` |

## Decisions

**ntfy rather than a mailbox.** Neither issuer offers authenticator-app enrollment, so every account will be challenged with a code no machine can compute. IMAP was the alternative; it needs a distinct address on file at each bank and a shared mailbox risks one run reading the other person's code. ntfy is one tap on a phone instead. Every account is `codeSources = ["ntfy"]` — `"totp"` is *not* a preference that falls through to the rung behind it, so it goes in only alongside a real `TOTP Secret` field in pass.

**ntfy's auth database is provisioned from the environment, not the CLI.** `NTFY_AUTH_USERS` / `NTFY_AUTH_ACCESS` / `NTFY_AUTH_TOKENS` come from a colmena key built out of pass, so there is no `ntfy user add` step to remember and nothing to restore if `/var/lib/ntfy-sh` is lost — which matters, because that directory stays on the tmpfs root by design. The one consequence is that a token minted at runtime through `/v1/account/token` does not survive a reboot while the provisioned one does, so the phones should log in with username and password. `auth-default-access: deny-all` — every topic is private and the ACLs are the only way in. Password hashes are `mkpasswd -m bcrypt -R 10`.

**The offer adder talks to ntfy over loopback.** nginx terminates TLS for the phones; the service, on the same box, uses `http://127.0.0.1:2586` directly. That keeps the internal CA out of bun's certificate store, which does not read the system trust store the way the rest of the host does.

**The browser profiles get their own tank dataset.** `/` is a tmpfs and `/var/lib` is not otherwise covered, so `tank/persisted-state/offer-adder` mounts at `/var/lib/offer-adder` natively under `import-tank` — which the unit now `Requires`, so a catch-up run before the pool is imported fails loudly instead of writing profiles somewhere `zfs mount -a` then shadows. It holds live bank sessions and a restored stale copy earns a challenge on every account anyway, so neither backup takes it: excluded from run-backup's `zfs send -R` (opt-out), and the borg job is opt-in on `net.prussin:backup`, which inherits — so confirm no ancestor sets it rather than assuming an unset child is enough.

**`sealed = false`.** colmena hands over the plaintext document, so `LoadCredential` rather than `LoadCredentialEncrypted`. systemd still stages it in the per-unit tmpfs; what is given up is the TPM binding. The credentials key uses `destDir = "/secrets"` — `/run/keys` is a tmpfs colmena only refills on deploy.

**09:17 and 19:17, not 03:17 and 15:17.** ntfy waits five minutes for a reply. A challenge at 3am reaches nobody and costs that account its run.

**No secret in argv, and none on stdout on failure.** `ps` is world-readable on the deploying host, so both key commands pass values to `jq` through the environment; `getOfferAdderCredentials` assembles the document into a variable so a failed lookup emits nothing at all rather than a partial document, and the ntfy token is read by a plain assignment ahead of the loop — `VAR="$(...)" prog` is the one construct `set -e` cannot see.

## Verification

No nix binary in the session environment initially, so this was checked by building one.

**Against the versions this lock actually pins**, which is not the same as the branch `flake.nix` names — the lock's root `nixpkgs` records `original.ref = "nixos-unstable"` (pre-existing, untouched here), so crux gets `d407951`:

- **ntfy 2.25.0**, not 26.05's 2.26.0. Started with the generated `server.yml` and the generated environment file: anonymous publish denied (403), off-ACL topic denied (403), token publish accepted, human basic-auth accepted, wrong password rejected (401), `/v1/account/token` works for provisioned users so the phone app can log in. Then end to end through the app's own code — `ntfyCodeSource` published the alert with the provisioned token, streamed the reply topic, and picked up a code published back by the "phone" user. Verified identically on 2.26.0. `eval crux` cannot catch a version problem here, because the provisioning goes through freeform env vars.
- **playwright 1.61.1.** At `9fbb54b`, the nixpkgs this lock pins for the offer-adder, `playwright-driver` is 1.61.1, and the offer-adder's catalog pins `"playwright": "1.61.1"` bare. That exact match is the condition `docs/DEPLOYMENT.md` requires or the first `launchPersistentContext` fails.
- `services.ntfy-sh.environmentFile` exists at the locked rev, and `jq` is 1.8.1 (the object-value syntax is parenthesised, so 1.7 would work too).

**Everything else:**

- `alejandra --check`, `statix check`, `deadnix --fail` — all clean.
- Both new machine modules evaluated against a real nixpkgs tree (with a stub for colmena's `deployment.keys`), asserting the generated `offer-adder.service`, `offer-adder.timer`, `ntfy-sh.service`, `server.yml` and `offers.config.json`. No failed assertions. CI's own `eval crux` job instantiates the whole machine.
- The generated `offers.config.json` parsed with the app's own `loadConfig`, and every account's ladder built with the app's own `buildCodeSource` against a credentials document carrying no TOTP secrets — the state the deployment is actually in.
- Both key commands run against a fake pass store, including a password containing `$`, `'` and `"`. Every failure path — missing `Token`, nonexistent ntfy entry, missing `Username`, odd argument count, nonexistent bank entry — exits 1 with empty stdout.
- The lock adds 8 nodes, all under `credit-card-offer-adder`, and re-pins nothing: walking the resolved input graph from `root`, every pre-existing path resolves to a byte-identical locked source. `bun2nix.nixpkgs` follows the offer-adder's, so there is exactly one extra nixpkgs.

## Before the first run

```sh
# -p because tank/persisted-state is lyra's naming; nothing shows one on crux yet.
# It still applies -o mountpoint= to the leaf, only the ancestors go propertyless.
zfs create -p -o mountpoint=/var/lib/offer-adder tank/persisted-state/offer-adder
zfs get -s local,inherited net.prussin:backup tank tank/persisted-state   # expect no `true`
```

(An earlier revision of this description claimed `run-backup` had to wait for the dataset. It does not — `zfs send -X` validates its argument for name syntax only and never resolves it, so the exclusion is inert until the dataset exists. Corrected on the `backup.nix` thread.)

## Not included

Nothing in `credit-card-offer-adder` needed to change. Its NixOS module already supports everything this deployment needs.