### PR TITLE
[crux] Add a Chromium build environment

### DIFF
--- a/config/machines/crux/chromium-build.nix
+++ b/config/machines/crux/chromium-build.nix
@@ -1,0 +1,112 @@
+{
+  config,
+  pkgs,
+  utils,
+  ...
+}: let
+  zfs = pkgs.callPackage ../../../lib/zfs.nix {};
+
+  # tank-fast is the NVMe and much the better disk for ninja, but it is also
+  # the 500G that holds /nix, so the dataset is created with `-o quota=200G`:
+  # an overrun then fails the build rather than the machine.  Moving to tank is
+  # not a one-line change here -- tank is LUKS with detached keys and is
+  # imported by import-tank.service, so its datasets mount natively under
+  # `zfs mount -a` rather than through fileSystems, and run-backup's
+  # `zfs send -R` would replicate the tree to the external disk unless it is
+  # added to that command's -X list.
+  pool = "tank-fast";
+
+  buildRoot = "/build";
+in {
+  # /build rather than /home because this is machine-scoped regenerable
+  # scratch, not user state: the /home datasets on this fleet are persisted and
+  # backed up, and on crux one would land on tank with everything the comment
+  # above describes.
+  #
+  # nofail so that a missing dataset cannot fail local-fs.target, which would
+  # leave crux in emergency.target with no sshd -- recoverable only at the
+  # physical console, on the box that serves the house's DNS.  nofail also
+  # drops the mount's implicit Before=local-fs.target (and its
+  # After=local-fs-pre.target, which nothing here needs), so x-systemd.before
+  # puts the ordering the tmpfiles rules depend on back, without making the
+  # mount required again.
+  fileSystems = zfs.mkZfsFileSystems {
+    "${pool}/chromium" = {
+      mountpoint = buildRoot;
+      options = ["defaults" "nofail" "x-systemd.before=local-fs.target"];
+    };
+  };
+
+  systemd = {
+    tmpfiles.rules = [
+      "d ${buildRoot} 0755 ${config.primary-user.name} users -"
+
+      # /tmp is tmpfs, so it is RAM; a Chromium link there takes the machine
+      # out.  This one is on disk and so does not empty on reboot the way /tmp
+      # does, hence the age.
+      "d ${buildRoot}/tmp 1777 root root 10d"
+    ];
+
+    # x-systemd.before fixes the boot ordering, but not the deploy: on the
+    # switch that introduces ${buildRoot}, switch-to-configuration restarts
+    # sysinit-reactivation.target (which re-runs systemd-tmpfiles) and blocks
+    # on it before starting new mounts, so the rules above land on the tmpfs
+    # root and the mount then hides them.  Redoing them here, after the mount,
+    # is what makes the dataset root come out owned by the primary user with
+    # its tmp directory present.  A failed build.mount already degrades the
+    # system on its own; what this adds is that repair, plus catching the
+    # cases the mount unit cannot report -- masked or stopped, unmounted after
+    # boot, or something other than the dataset mounted over it.
+    #
+    # Deliberately no RemainAfterExit: a oneshot that goes back to inactive is
+    # pulled in afresh by every switch's multi-user.target job, which is how
+    # this runs on each deploy rather than only the first.  It does mean a
+    # healthy unit reads "inactive (dead)" rather than "active (exited)", so
+    # check ${buildRoot} itself rather than the unit's state.
+    services.setup-build-mount = {
+      description = "Set ${buildRoot} up on the ${pool}/chromium dataset";
+      wantedBy = ["multi-user.target"];
+      after = ["${utils.escapeSystemdPath buildRoot}.mount" "local-fs.target"];
+      serviceConfig = {
+        Type = "oneshot";
+
+        # systemd-tmpfiles exits 65/73 when any file under /etc/tmpfiles.d is
+        # bad, whether or not it is one of ours.  Upstream's own tmpfiles units
+        # treat both as success; failing here would fail every deploy to crux.
+        SuccessExitStatus = "DATAERR CANTCREAT";
+        ExecStart = pkgs.writeShellScript "setup-build-mount" ''
+          set -eu
+          mounted=$(${pkgs.util-linux}/bin/findmnt --noheadings --output SOURCE --mountpoint ${buildRoot} || true)
+          if [ "$mounted" != "${pool}/chromium" ]; then
+            echo "${buildRoot} is not ${pool}/chromium (found: ''${mounted:-nothing})." >&2
+            echo "TMPDIR points into it, so anything using it would write to RAM." >&2
+            exit 1
+          fi
+          exec ${config.systemd.package}/bin/systemd-tmpfiles --create --prefix=${buildRoot}
+        '';
+      };
+    };
+  };
+
+  # Chromium's toolchain is prebuilt dynamically-linked binaries fetched by
+  # gclient hooks, which cannot run against the store unaided.  If one dies on
+  # a missing .so, add it to programs.nix-ld.libraries -- systemPackages will
+  # not help.
+  programs.nix-ld.enable = true;
+
+  environment = {
+    systemPackages = [
+      pkgs.curl
+      pkgs.git
+      pkgs.lsb-release # depot_tools probes it
+      pkgs.python3
+    ];
+
+    # sessionVariables rather than variables: the primary user's shell is
+    # nushell, which sources neither /etc/profile nor home-manager's
+    # hm-session-vars.sh, so the host-wide option is the only one that reaches
+    # the shell that needs it.  This covers every PAM session, including
+    # `ssh crux <cmd>`, but no system service.
+    sessionVariables.TMPDIR = "${buildRoot}/tmp";
+  };
+}

--- a/config/machines/crux/default.nix
+++ b/config/machines/crux/default.nix
@@ -5,6 +5,7 @@
     ../../profiles/server
 
     ./backup.nix
+    ./chromium-build.nix
     ./circinus.nix
     ./dns.nix
     ./dynamic-dns.nix

--- a/lib/zfs.nix
+++ b/lib/zfs.nix
@@ -4,6 +4,7 @@
       lib.nameValuePair options.mountpoint {
         inherit device;
         neededForBoot = options.neededForBoot or false;
+        options = options.options or ["defaults"];
         fsType = "zfs";
       }
   );


### PR DESCRIPTION
Makes `crux` able to build Chromium, for the `domicile` engine-fork spike. New
`config/machines/crux/chromium-build.nix`, imported from `crux`'s
`default.nix`, plus a one-line `options` passthrough in `lib/zfs.nix`.

## What it does

- **`/build`** — `tank-fast/chromium`, a dedicated dataset. Machine-scoped
  regenerable scratch rather than user state, which is why it isn't a `/home`
  dataset: those are persisted and backed up, and on crux one would land on
  `tank` with all the entanglement described under *The pool choice* below.
- **`nofail` + `x-systemd.before=local-fs.target`** — `nofail` so a missing
  dataset can't fail `local-fs.target` and leave crux in `emergency.target`
  with no `sshd`, on the box that serves the house's DNS. `nofail` also drops
  the mount's implicit `Before=local-fs.target` (`systemd.mount(5)`), which the
  tmpfiles rules depend on, so `x-systemd.before=` restores the ordering
  without making the mount required again. `mkZfsFileSystems` gains an
  `options` passthrough for this, defaulting to exactly what it emitted before.
- **`setup-build-mount`** — `x-systemd.before=` fixes the *boot* ordering but
  not the *deploy* one: `switch-to-configuration` restarts
  `sysinit-reactivation.target` (re-running `systemd-tmpfiles`) and blocks on
  it before starting new mounts, so on the switch that introduces `/build` the
  rules land on the tmpfs root and the mount hides them. This unit redoes them
  after the mount, and fails — degrading the system — when `/build` isn't
  `tank-fast/chromium`.
- **`TMPDIR=/build/tmp`** — `/tmp` is tmpfs, so it is RAM; a Chromium link
  there would take the machine out. `sessionVariables`, not `variables`: the
  primary user's shell is nushell, which sources neither `/etc/profile` nor
  home-manager's `hm-session-vars.sh`. Aged `10d`, since moving off tmpfs loses
  the reboot-empties-it property.
- **`programs.nix-ld`** — the toolchain gclient hooks fetch is prebuilt,
  dynamically-linked binaries that can't run against the store unaided.
- `curl`, `git`, `lsb-release` (depot_tools probes it), `python3`.

## Verified

`alejandra --check`, `statix check`, `deadnix --fail` pass; CI green on the
previous head including **`eval crux`** and **`eval lyra`** — the latter is what
would catch a regression from the `lib/zfs.nix` change, which lyra uses for ~40
datasets.

Confirmed by eval on the current head: the rendered fstab line is
`tank-fast/chromium /build zfs defaults,nofail,x-systemd.before=local-fs.target 0 0`,
so the option reaches systemd-fstab-generator rather than only the Nix attrset;
`setup-build-mount` renders as

```
[Unit]
After=build.mount local-fs.target

[Service]
ExecStart=/nix/store/...-setup-build-mount
SuccessExitStatus=DATAERR CANTCREAT
Type=oneshot
```

with no `RemainAfterExit` (deliberate — see below); its script builds and passes
`bash -n`; `sessionVariables.TMPDIR` and `variables.TMPDIR` are both
`/build/tmp`, so bash login shells still work; and an existing
`mkZfsFileSystems` caller still comes out `["defaults"]`.

The deploy-ordering claim was verified against nixpkgs 26.05 source:
`switch-to-configuration-ng/src/main.rs:2439-2452` (restart and block) vs
`:2555` (start units, incl. new mounts per the comment at `:1255`), and
`nixos/modules/system/boot/systemd/tmpfiles.nix:256`.

Not verified: `cli deploy`, and the proof build.

## Before deploying

The repo declares the mount; it does not create the dataset. As root on `crux`:

```sh
zfs create -o mountpoint=legacy \
           -o quota=200G \
           -o compression=zstd \
           -o atime=off \
           -o xattr=sa \
           -o acltype=posixacl \
           -o com.sun:auto-snapshot=false \
           -o sync=disabled \
           tank-fast/chromium
```

Then `cli fix format && cli test`, `cli deploy`, and verify **the directories,
not the unit**:

```sh
ssh crux 'ls -ld /build /build/tmp'   # cprussin:users, and 1777 on tmp
```

A healthy `setup-build-mount` is `inactive (dead)`, not `active (exited)` —
that's what makes each switch re-run it — so `systemctl status` on it reads
like "never ran" and is the wrong thing to look at. `systemctl is-system-running`
works as a coarse check. If the dataset were missing, the unit fails and the
deploy exits non-zero; creating it and deploying again clears that by itself,
since stc calls `reset_failed()` before it starts units.

**`quota=200G` is what bounds the risk**: an overrun fails the build instead of
filling the pool `/nix` lives on. `sync=disabled` is the biggest ninja win on
ZFS and the tree is regenerable. `com.sun:auto-snapshot=false` is defensive
only — `zfs-auto-snapshot` is opt-in per dataset, so it matters just if the
property is ever set at the pool root and inherited.

Deliberately **not** setting `primarycache=metadata`, though an earlier revision
did. It would pessimise the first-build wall-clock number that is this
exercise's whole deliverable, by an amount nobody could quantify. If ARC
pressure on immich/frigate/home-assistant shows up during the proof run,
`zfs_arc_max` targets it directly.

**One cost worth knowing**: while `/build` is unmounted, `setup-build-mount`
fails, so `cli deploy` to crux exits non-zero — including deploys that have
nothing to do with this module. That's deliberate (a machine that deploys clean
while `TMPDIR` points into RAM is the worse outcome), but it's a real cost, and
removing this module is how to opt out of it once the spike is done.

## The pool choice

`tank-fast` — the NVMe, and much the better disk for ninja. Headroom checked on
the machine, and it is comfortable rather than marginal:

```
NAME        SIZE  ALLOC   FREE  FRAG   CAP  HEALTH
tank-fast   464G  10.3G   454G   35%    2%  ONLINE
```

`/nix`, `/var/log` and `/secrets` together account for that 10.3G, so the
200G-capped build lands around 210G of 464G — about 45% capacity, well clear of
the ~80% fill where ZFS starts degrading.

Recorded for whoever reads this later: moving to `tank` would **not** be a
one-line change to `pool`. `tank` is LUKS with detached keys and imported by
`import-tank.service`, so none of its datasets go through `fileSystems` — they
mount natively under `zfs mount -a` (`hardware.nix:33`, and every
`import-tank.service` dependency in `nvr.nix`, `photos.nix`, `library.nix`). A
`fileSystems` entry would try to mount before the pool is imported. It would
also need adding to `run-backup`'s `zfs send -R -X` list (`backup.nix:52`), or
200 GB of regenerable scratch gets replicated to the external disk. Borg is
opt-in per dataset via `net.prussin:backup`, so that side needs nothing.

## Decisions

- **No `zramSwap`.** An earlier revision had it. It doesn't add memory, it
  competes with ZFS ARC for the same RAM, and a burst allocation from an lld
  link is where that goes worst — a line changing host-wide memory behavior for
  frigate, immich and the libvirtd VMs, speculatively, for a spike. If the link
  OOMs, the levers are `zfs_arc_max`, real swap on the NVMe, or capping link
  parallelism — all of which want real numbers to size.
- **No `ninja` in `systemPackages`.** depot_tools ships one via `autoninja`, and
  upstream's `tools/nix/shell.nix` provides another. A third ahead of them on
  `PATH` is version skew, not convenience.
- **`TMPDIR` host-wide rather than per-user.** The per-user mechanism
  (`home.sessionVariables` → `hm-session-vars.sh`) is precisely the one nushell
  doesn't source, so this is the only lever that reaches the shell that needs
  it. It covers PAM sessions only — no system service, no `nix-daemon`.
- **Kept `nix-ld`.** If `tools/nix/shell.nix` proves sufficient alone, drop it.
- **Left `max-jobs` at `lib.mkDefault 16`.** It only affects Nix builds, and
  this isn't one. Worth revisiting if `crux` becomes a remote builder.

## Still outstanding

The handoff's actual deliverable is the first-build wall-clock time and `du -sh
/build`, which feed a decision in domicile's `ENGINE-FORK.md`. The proof run
(`fetch --nohooks chromium`, `gn gen`, `autoninja -C out/Domicile chrome`) still
has to happen on the machine.