### PR TITLE
[crux] Document how Chromium actually gets built

### DIFF
--- a/config/machines/crux/chromium-build.nix
+++ b/config/machines/crux/chromium-build.nix
@@ -1,3 +1,32 @@
+# Building Chromium here means going through upstream's own Nix shell, which is
+# what supplies pkg-config and the other host tools gn probes for:
+#
+#     cd /build/chromium/src
+#     nix develop "path:./tools/nix"
+#
+# The path: prefix matters -- without it the flake ref resolves to the
+# enclosing git repo and nix copies Chromium's tracked tree into the store
+# first.  Gitignored paths are excluded, which is the only reason that is
+# merely slow rather than catastrophic: out/ is most of the checkout.
+#
+# --command does not work here, and not for the reason it looks like: nix
+# passes everything after that flag through untouched, but upstream's shell
+# is a buildFHSEnv whose shellHook execs bwrap before nix's appended `exec
+# <command>` is ever reached, so you land in an interactive bash having run
+# nothing.  Upstream ships an escape hatch for scripting it:
+#
+#     NIX_SHELL_RUN='autoninja -C out/Domicile chrome' nix develop "path:./tools/nix"
+#
+# TMPDIR is nested rather than preserved: nix develop drops the derivation's
+# value, then exports a fresh mktemp directory created under the caller's, so
+# the shell sees /build/tmp/nix-shell.XXXXXX.  bwrap leaves /build visible at
+# the same path, so the build's temp files still land on the dataset rather
+# than tmpfs, which is the point.  Those per-shell directories are not removed
+# on exit -- that is what the age on the tmpfiles rule below is for.
+#
+# Measured 2026-08-29, first clean build, is_component_build with
+# symbol_level=0: 4h16m wall on 16 jobs, 97G of the 200G quota.  Both would
+# grow substantially with symbols or a second out/ configuration.
 {
   config,
   pkgs,
@@ -92,6 +121,14 @@ in {
   # gclient hooks, which cannot run against the store unaided.  If one dies on
   # a missing .so, add it to programs.nix-ld.libraries -- systemPackages will
   # not help.
+  #
+  # It is not consulted inside upstream's shell: that is a buildFHSEnv, so the
+  # loader at /lib64 in the container is the FHS env's own rather than nix-ld's
+  # stub.  Whether anything still needs it is untested -- the first `fetch
+  # chromium` is necessarily driven from outside that shell, so that is where
+  # it would earn its place.  Testing costs a switch and a second rather than a
+  # rebuild: turn this off and run a fetched binary directly, e.g.
+  # third_party/llvm-build/Release+Asserts/bin/clang --version.
   programs.nix-ld.enable = true;
 
   environment = {


### PR DESCRIPTION
Comment-only follow-up to [#28](https://github.com/cprussin/dotfiles/pull/28),
recording what the first real build turned up. No behaviour change — the diff
is entirely comments in `config/machines/crux/chromium-build.nix`.

## Why

The build worked, but getting there cost several dead ends the module said
nothing about, and each one looked like a different problem than it was.

- **It goes through upstream's `tools/nix` shell, not a bare `autoninja`.**
  `gn gen` fails on a missing `pkg-config` otherwise — a missing *host tool*,
  which reads like the nix-ld case in the existing comment but isn't, since
  nix-ld only helps prebuilt binaries find libraries.
- **The `path:` prefix on the flake ref is load-bearing.** Without it the ref
  resolves to the enclosing git repo (`git+file:///…?dir=tools/nix`) and nix
  copies Chromium's **tracked tree** into the store first. Gitignored paths are
  excluded — and `out/` is gitignored, i.e. most of the 97 GB — which is the
  only reason that's slow rather than catastrophic.
- **`--command` silently does nothing, and `NIX_SHELL_RUN` is how to script
  it.** Not an argument-parsing problem: nix passes everything after that flag
  through untouched. Upstream's shell is a `buildFHSEnv` whose `shellHook`
  execs bwrap before the `exec` line nix appends is ever reached, so you land
  in an interactive bash having run nothing — which then looks like every
  subsequent command mysteriously failing, because they're going to a different
  shell than you think. `NIX_SHELL_RUN='…' nix develop "path:./tools/nix"` is
  upstream's documented escape hatch, and it works with `nix develop` as well
  as `nix-shell`.
- **`TMPDIR` is nested, not preserved.** `nix develop` drops the derivation's
  value and then exports a fresh `mktemp -d -t nix-shell.XXXXXX`, created under
  the caller's — so the shell sees `/build/tmp/nix-shell.XXXXXX`. bwrap leaves
  `/build` visible at the same path, so the build's temp files still land on
  the dataset rather than tmpfs, which is the point. Those per-shell
  directories are never removed on exit, which is what the `10d` tmpfiles age
  from #28 quietly handles.

## The measured cost

This is what the `domicile` side is deciding against, so it belongs in the repo
rather than only in a PR thread:

| | |
|---|---|
| Wall clock | **4h16m21s** — first clean build, cold |
| CPU time | ~60.7 core-hours (57.5 user + 3.2 sys) |
| Effective parallelism | ~14.2× across 16 jobs (~89% efficiency) |
| Disk | **97 GB** of the 200 GB quota (**48.5%**) |
| Steps | 56,376 executed (55,962 local + 414 no-exec), plus 29,340 reported skipped |

GN args were `is_debug=false symbol_level=0 is_component_build=true` with the
Wayland/Ozone flags — the cheap end of the range. Symbols or a second `out/`
configuration would move the disk figure substantially against that 48.5%,
which is the number to watch rather than the wall clock.

## `programs.nix-ld`

I said in #28 that if upstream's shell proved sufficient, nix-ld should be
dropped rather than carried for nothing. Half of that is now settled and half
isn't, and the comment says which is which.

**It cannot have been used during the build.** `buildFHSEnv` synthesises its own
`/lib64` inside the bwrap namespace, holding a real loader, so nix-ld's stub is
never bound in — that follows from what the shell is, without needing an
experiment.

**Whether anything else needs it is untested.** The case that would matter is
the first `fetch chromium`, which is necessarily driven from outside that shell
since there's no checkout yet. The comment names the one-line test — turn the
option off, switch, and run a fetched binary directly — rather than my earlier
claim that settling it costs a full rebuild. It doesn't; nothing about the
question involves compiling anything.

## Verified

`alejandra --check`, `statix check`, `deadnix --fail` pass, and the module still
evaluates against nixpkgs 26.05. Comments only, so no config change to check
beyond that.

Four review rounds went into the accuracy of these comments. Rounds 1 and 2
each found mechanisms asserted confidently for behaviour that had only been
observed by its result — including one where round 1's correction was itself
wrong and round 2 restored the original. The claims above are the ones that
survived independent verification: `nix develop` experiments, nixpkgs 26.05
source, and upstream's own `tools/nix`.