### PR TITLE
[lyra] Cast the screen to the Fire TV with Sunshine

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -48,5 +48,6 @@ Then use ~cli~:
 ** More documentation
 
 - [[./docs/adding-a-machine.org][Adding a new machine]]
+- [[./docs/casting.org][Casting the screen to a TV]]
 - [[./docs/nixpkgs-pinning.org][How nixpkgs is pinned (no channels)]]
 - [[./docs/secrets.org][How secrets are deployed]]

--- a/config/machines/lyra/default.nix
+++ b/config/machines/lyra/default.nix
@@ -120,6 +120,7 @@ in {
         "tank/persisted-state/iwd".mountpoint = "/var/lib/iwd";
         "tank/persisted-state/log".mountpoint = "/var/log";
         "tank/persisted-state/root-containers".mountpoint = "/var/lib/containers";
+        "tank/persisted-state/sunshine".mountpoint = "/home/${config.primary-user.name}/.config/sunshine";
         "tank/persisted-state/syncthing".mountpoint = "/home/${config.primary-user.name}/.cache/syncthing";
         "tank/persisted-state/syncthing-config".mountpoint = "/home/${config.primary-user.name}/.config/syncthing";
         "tank/persisted-state/wluma".mountpoint = "/home/${config.primary-user.name}/.local/share/wluma";

--- a/config/modules/ui/launcher/apps/cast.nix
+++ b/config/modules/ui/launcher/apps/cast.nix
@@ -1,0 +1,19 @@
+{
+  writeShellScript,
+  systemd,
+}:
+writeShellScript "cast" ''
+  systemctl=${systemd}/bin/systemctl
+
+  # Match on the state rather than `is-active --quiet`'s exit status: that
+  # reports failure while the service is still `activating`, so a second `cast`
+  # during startup would issue another `start` instead of stopping.
+  case "$($systemctl --user is-active sunshine)" in
+    inactive | failed)
+      $systemctl --user start sunshine
+      ;;
+    *)
+      $systemctl --user stop sunshine
+      ;;
+  esac
+''

--- a/config/modules/ui/launcher/default.nix
+++ b/config/modules/ui/launcher/default.nix
@@ -54,6 +54,7 @@ in {
           brightness = pkgs.callPackage ./apps/brightness.nix {};
           btop = mkTerminalApp "btop" "${pkgs.btop}/bin/btop";
           calendar = mkGoogleApp "calendar" "https://calendar.google.com";
+          cast = pkgs.callPackage ./apps/cast.nix {};
           chatgpt = "${pkgs.chatgpt-desktop}/bin/chatgpt";
           chrome = pkgs.writeShellScript "chrome" "${pkgs.launcher}/bin/browse --browser chrome $*";
           chromium = pkgs.writeShellScript "chromium" "${pkgs.launcher}/bin/browse --browser chromium $*";
@@ -91,6 +92,7 @@ in {
           sotd = mkWebApp "sotd" "https://docs.google.com/spreadsheets/d/168kHAuFM2bOHaQvyzkbWBF4206jV5bXpg0ubT3fSSJk?authuser=connor@prussin.net";
           steam = "${pkgs.steam}/bin/steam";
           stop-screen-record = pkgs.writeShellScript "stop-screen-record" "pkill wf-recorder";
+          sunshine = mkWebApp "sunshine" "https://localhost:47990";
           syncthing = mkWebApp "syncthing" "http://localhost:8384";
           systemctl = mkModal "systemctl" "${pkgs.sysz}/bin/sysz";
           tor-browser = pkgs.writeShellScript "tor-browser" "${pkgs.launcher}/bin/browse --browser tor-browser $*";

--- a/config/modules/ui/sunshine/default.nix
+++ b/config/modules/ui/sunshine/default.nix
@@ -1,0 +1,64 @@
+{config, ...}: let
+  # Sunshine's ports are offsets from its base port.
+  mkPorts = map (offset: config.services.sunshine.settings.port + offset);
+in {
+  services.sunshine = {
+    enable = true;
+
+    # Sunshine captures the screen and injects input events, so it does not run
+    # for the whole session: the `cast` launcher app starts and stops it.
+    autoStart = false;
+
+    # KMS capture reads planes that belong to another DRM master, which needs
+    # CAP_SYS_ADMIN; this grants it through a setcap wrapper.
+    capSysAdmin = true;
+
+    settings = {
+      # sway is wlroots, but Sunshine's wlr-screencopy backend fails there:
+      # frame capture errors out on EGL image creation and the stream comes
+      # through as black with horizontal lines (LizardByte/Sunshine#5258).
+      # Grab the framebuffer from DRM/KMS instead.
+      #
+      # `output_name` is deliberately unset so Sunshine streams the default
+      # display: which output that should be depends on the kanshi profile in
+      # effect, and there is no stable answer to bake in here.
+      capture = "kms";
+
+      # The web UI answers any LAN host by default; restrict it to local
+      # requests.  The `sunshine` launcher app opens it from this machine,
+      # which is the only place it is ever used from.  Note this rejects
+      # remote requests rather than changing what Sunshine binds: it still
+      # listens on every address, so the port stays closed below too.
+      origin_web_ui_allowed = "pc";
+    };
+  };
+
+  # This is `services.sunshine.openFirewall`'s own list with the web UI (offset
+  # +1) taken out, and it is written out here so that dropping it back in is
+  # visible in review.  That port is the one endpoint `origin_web_ui_allowed`
+  # does not cover: `savePassword` skips `authenticate` outright while no admin
+  # password is set, and the origin check lives inside `authenticate`, so
+  # between the first `cast` and finishing setup anything that can reach it can
+  # claim the account.  Everything else on these ports is either harmless to
+  # answer (`/serverinfo`, and `/pair`, which is gated on the PIN) or needs a
+  # paired client certificate.
+  #
+  # These are open on every interface, unlike the interface-scoped rules
+  # elsewhere in this repo: the laptop casts from wifi or the dock's ethernet
+  # depending on the day, and this also puts them on the tailnet.
+  networking.firewall = {
+    # -5 nvhttp HTTPS, 0 nvhttp HTTP, 21 RTSP.  (+1 is the web UI.)
+    allowedTCPPorts = mkPorts [(-5) 0 21];
+
+    # 9 video, 10 control, 11 audio, 13 mic, 21 RTSP.
+    allowedUDPPorts = mkPorts [9 10 11 13 21];
+  };
+
+  # Enabling Sunshine turns on Avahi publishing: the upstream module sets
+  # `services.avahi.publish.enable` and `.userServices`, and since nothing here
+  # defines either, its `mkDefault` takes effect.  That is what lets Moonlight
+  # discover the laptop by name, but it is system-wide and not tied to Sunshine
+  # running: lyra advertises its hostname and addresses on every network it
+  # joins from here on.  Setting `publish.enable = false` in the avahi module
+  # would override it, at the cost of adding the laptop to Moonlight by IP.
+}

--- a/config/profiles/pc/default.nix
+++ b/config/profiles/pc/default.nix
@@ -37,6 +37,7 @@
     ../../modules/ui/mako
     ../../modules/ui/mpv
     ../../modules/ui/plymouth
+    ../../modules/ui/sunshine
     ../../modules/ui/sway
     ../../modules/ui/swayidle
     ../../modules/ui/swaylock

--- a/docs/casting.org
+++ b/docs/casting.org
@@ -1,0 +1,111 @@
+* Casting the screen to a TV
+
+Screen casting is [[https://github.com/LizardByte/Sunshine][Sunshine]] on the
+laptop and [[https://moonlight-stream.org/][Moonlight]] on the TV.  Moonlight is
+a normal Fire TV app, so this works on a Fire TV without sideloading anything.
+
+Miracast is deliberately not used.  Fire TV's built-in "Display Mirroring" is
+Miracast, but every Linux implementation of the sending side needs Wi-Fi Direct
+through NetworkManager or wpa_supplicant, and this repo runs [[../config/modules/system/devices/wifi/default.nix][iwd]] with neither.
+Sunshine also gets hardware encoding, audio, and remote input, none of which
+Miracast would give us.
+
+** One-time setup
+
+*** 1. Create the state dataset, before deploying
+
+Sunshine keeps its web UI credentials and its paired client certificates in
+~~/.config/sunshine~.  ~/~ is a tmpfs on lyra, so that is a ZFS dataset.  Like
+every other dataset here it is mounted from ~fileSystems~ rather than by ZFS
+itself, so it needs a legacy mountpoint:
+
+#+BEGIN_SRC bash
+  sudo zfs create -o mountpoint=legacy tank/persisted-state/sunshine
+#+END_SRC
+
+This has to come first: [[../config/machines/lyra/default.nix][lyra's config]] declares the mount, so once that is
+deployed a boot with no dataset behind it fails.
+
+*** 2. Deploy
+
+#+BEGIN_SRC bash
+  cli deploy --on lyra
+#+END_SRC
+
+*** 3. Give the dataset to the user
+
+A new dataset's root is owned by root, and ~install-user-mountpoints~ runs
+before the ZFS mounts, so nothing else fixes it.  Without this Sunshine cannot
+create its ~credentials/~ directory and exits immediately on every start:
+
+#+BEGIN_SRC bash
+  sudo chown cprussin:users /home/cprussin/.config/sunshine
+#+END_SRC
+
+*** 4. On the TV
+
+Install "Moonlight Game Streaming" from the Amazon Appstore.
+
+*** 5. Pair
+
+Start Sunshine with ~cast~ in the launcher, then open its web UI with
+~sunshine~ in the launcher ([[https://localhost:47990]]).  That port is not
+opened in the firewall, so the web UI is reachable from this machine only.  It
+is served over HTTPS with a self-signed certificate, so the browser warning is
+expected.  Create the web UI username and password when it asks.
+
+Now open Moonlight on the TV.  It finds the laptop over mDNS if they are on the
+same network; otherwise add the laptop's IP by hand.  Select it, and Moonlight
+shows a PIN.  Enter that PIN under "PIN" in the Sunshine web UI.  Pairing
+survives reboots.
+
+** Casting
+
+Run ~cast~ in the launcher to start Sunshine, then pick "Desktop" in Moonlight.
+Run ~cast~ again to stop.
+
+Run ~presentation~ alongside it.  KMS capture reads a live output's framebuffer,
+so the stream drops once the screen blanks, and driving the laptop from the Fire
+TV remote does not keep the session awake: Moonlight sends the remote as a
+gamepad, Sunshine injects it as a virtual joystick, and libinput does not count
+joystick events as activity.  Only a mouse or keyboard on either end resets the
+idle timer.
+
+~cast~ deliberately does not do this itself.  ~presentation~ stops [[../config/modules/ui/swayidle/default.nix][swayidle]]
+outright, and swayidle owns the ~lock~ and ~before-sleep~ handlers as well as
+the idle timeouts -- so while it is off, ~loginctl lock-session~ does nothing
+and suspending no longer locks.  That is a deliberate thing to turn on, not
+something starting a cast should do quietly.
+
+** Notes
+
+- Sunshine streams the default display.  With several outputs connected that may
+  not be the one you want.  ~journalctl --user -u sunshine~ has a block like
+
+  #+BEGIN_EXAMPLE
+    -------- Start of KMS monitor list --------
+    Monitor 0 is eDP-1: BOE NE135A1M-NY1
+    --------- End of KMS monitor list ---------
+  #+END_EXAMPLE
+
+  and that monitor number goes in ~output_name~ in [[../config/modules/ui/sunshine/default.nix][config/modules/ui/sunshine]].
+  It is an index into Sunshine's own enumeration, assigned while walking
+  ~/dev/dri/card*~ and their active planes -- not a connector name.  So it can
+  move on a reboot, on plugging the dock in, or when a DisplayLink output shows
+  up, quite apart from a Sunshine version bump.  Check the log again rather than
+  trusting a number that worked last time.
+
+- The web UI's "Configuration" page cannot save anything.  Because
+  ~services.sunshine.settings~ is set, Sunshine runs against a config file in
+  the nix store -- change [[../config/modules/ui/sunshine/default.nix][config/modules/ui/sunshine]] and redeploy instead.  The
+  other pages do write: credentials, pairings, and the application list all live
+  in the dataset.  The "Desktop" entry Moonlight offers comes from the stock
+  ~apps.json~ Sunshine copies there on first start, and edits to it stick.
+
+- Moonlight sends keyboard, mouse, and gamepad input back, so the Fire TV remote
+  drives the laptop.  Nothing else on the network can: clients have to pair
+  first.
+
+- Capture is DRM/KMS rather than wlroots screencopy.  Sunshine's ~wlr~ backend
+  fails on sway 1.12: frame capture errors out on EGL image creation and the
+  stream arrives black with horizontal lines (LizardByte/Sunshine#5258).


### PR DESCRIPTION
Adds screen casting from lyra to the Fire TV: [Sunshine](https://github.com/LizardByte/Sunshine) on the laptop, [Moonlight](https://moonlight-stream.org/) on the TV.

## Why not Miracast

Fire TV's built-in "Display Mirroring" is Miracast. Every Linux sender (`gnome-network-displays`, `miraclecast`) needs Wi-Fi Direct through NetworkManager or wpa_supplicant, and we run iwd with neither — [NetworkManager's P2P support excludes iwd](https://github.com/benzea/gnome-network-displays). Moonlight is a first-class Fire TV app on the Amazon Appstore (no sideloading), and Sunshine additionally gets us hardware encoding, audio, and remote input.

## What's here

- `config/modules/ui/sunshine` — `services.sunshine`, imported by the `pc` profile (so lyra only; crux is on `server`).
  - `autoStart = false`: it captures the screen and injects input, so it only runs while casting.
  - `capture = "kms"` + `capSysAdmin`: Sunshine's `wlr` screencopy backend fails on sway 1.12 — frame capture errors out on EGL image creation and the stream arrives black with horizontal lines ([LizardByte/Sunshine#5258](https://github.com/LizardByte/Sunshine/issues/5258)).
  - `output_name` left unset — which output is "the" display depends on the kanshi profile in effect.
- `cast` launcher app — toggles Sunshine, and nothing else.
- `sunshine` launcher app — opens the web UI, where pairing PINs get entered.
- `tank/persisted-state/sunshine` on lyra for `~/.config/sunshine`; `/` is tmpfs, so web UI credentials and paired client certs would otherwise be lost every boot.
- `docs/casting.org` with the one-time setup.

### Firewall

The rules are written out rather than taken from `openFirewall`, which would also open the web UI at base+1. That port is the one thing `origin_web_ui_allowed = "pc"` does not cover: `savePassword` is guarded by `if (!config::sunshine.username.empty() && !authenticate(...))`, so while no admin password is set `authenticate()` — where the origin check lives — is skipped, and `validate_csrf_token` passes anything without an `Origin`/`Referer`. Between the first `cast` and finishing setup, anything that could reach tcp/47990 could `POST /api/password` and claim the account.

So only the streaming ports are opened (those require a paired client certificate), and the web UI stays on loopback, which is all the `sunshine` launcher app needs.

### On idle

Run `presentation` alongside `cast`. KMS capture reads a live output's framebuffer, so the stream drops when the screen blanks, and the Fire TV remote does *not* keep the session awake — Moonlight sends it as a gamepad, Sunshine injects a virtual joystick, and libinput doesn't count joystick events as activity.

`cast` deliberately doesn't stop swayidle itself: swayidle owns the `lock` and `before-sleep` handlers as well as the timeouts, so stopping it means `loginctl lock-session` does nothing and suspending no longer locks. That's a thing to turn on deliberately, not something starting a cast should do quietly.

## Manual steps

```bash
# 1. Before deploying — the mount is required at boot once lyra's config declares it.
#    Legacy mountpoint because lib/zfs.nix mounts these from fileSystems, not via ZFS.
sudo zfs create -o mountpoint=legacy tank/persisted-state/sunshine

# 2. Deploy
cli deploy --on lyra

# 3. After the mount exists. A new dataset's root is root-owned, and
#    install-user-mountpoints runs before the ZFS mounts, so nothing else fixes it;
#    without this Sunshine can't create credentials/ and exits on every start.
sudo chown cprussin:users /home/cprussin/.config/sunshine
```

Then: install "Moonlight Game Streaming" from the Amazon Appstore on the Fire TV, run `cast`, set the web UI username/password, and pair the TV with a PIN.

## Note on system-wide effects

Enabling Sunshine turns on Avahi publishing — the upstream module sets `services.avahi.publish.enable` and `.userServices`, and since nothing here defines either, its `mkDefault` takes effect. That's what makes Moonlight's discovery-by-name work, but it isn't tied to Sunshine running: lyra will advertise its hostname and addresses on every network it joins. Called out in the module comment.

## Testing

CI green on the previous head; running on this one. No NixOS toolchain in this environment, so this has not been deployed or exercised against a real Fire TV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oPrPoK4GJgFfT2E9qZsB1