### PR TITLE
[lyra] Cast to a headless 16:9 output instead of mirroring

### DIFF
--- a/config/modules/ui/launcher/apps/cast.nix
+++ b/config/modules/ui/launcher/apps/cast.nix
@@ -1,19 +1,122 @@
+# See docs/casting-design.org for why any of this is shaped the way it is.
 {
   writeShellScript,
+  coreutils,
+  gnugrep,
   systemd,
+  sway,
+  jq,
 }:
 writeShellScript "cast" ''
+  cat=${coreutils}/bin/cat
+  comm=${coreutils}/bin/comm
+  head=${coreutils}/bin/head
+  rm=${coreutils}/bin/rm
+  sort=${coreutils}/bin/sort
+  test=${coreutils}/bin/test
+  grep=${gnugrep}/bin/grep
   systemctl=${systemd}/bin/systemctl
+  swaymsg=${sway}/bin/swaymsg
+  jq=${jq}/bin/jq
 
-  # Match on the state rather than `is-active --quiet`'s exit status: that
-  # reports failure while the service is still `activating`, so a second `cast`
-  # during startup would issue another `start` instead of stopping.
+  outputFile="$XDG_RUNTIME_DIR/cast-output"
+
+  # Headless only: a monitor plugged in between the two samples below would
+  # otherwise land in the diff, and everything downstream takes a single name.
+  headlessOutputs() {
+    $swaymsg -t get_outputs | $jq -r '.[].name' | $grep '^HEADLESS-' | $sort
+  }
+
+  # Also runs before starting, because a cast can end without `cast` and the
+  # output outlives it.
+  unplug() {
+    if $test -f "$outputFile"
+    then
+      $swaymsg "output $($cat "$outputFile") unplug" > /dev/null 2>&1
+      $rm -f "$outputFile"
+    fi
+  }
+
+  # Match the state, not `is-active --quiet`'s status: that calls `activating`
+  # a failure, so a second `cast` during startup would start again.
   case "$($systemctl --user is-active sunshine)" in
     inactive | failed)
+      unplug
+
+      # A start outside `cast` exits 1 and can trip the unit's start limit,
+      # which would leave the layout built around a service that never comes up.
+      $systemctl --user reset-failed sunshine 2> /dev/null
+
+      # `create_output` takes no arguments and names them `HEADLESS-N` with N
+      # counting up, so the name has to be read back.
+      before="$(headlessOutputs)"
+      $swaymsg create_output > /dev/null
+      output="$($comm -13 <(echo "$before") <(headlessOutputs) | $head -n 1)"
+
+      if $test -z "$output"
+      then
+        echo 'cast: sway added no output; check the sway log' >&2
+        exit 1
+      fi
+
+      # Record before anything else can fail.
+      echo "$output" > "$outputFile"
+
+      # 1:1 on a 1080p TV.
+      $swaymsg "output $output scale 1" > /dev/null
+
+      # At the top of the focused output's column, so the pointer reaches the TV
+      # off the top edge.  Only that column counts -- see the design notes.
+      outputs="$($swaymsg -t get_outputs)"
+      read -r width height < <(echo "$outputs" | $jq -r --arg o "$output" \
+        'first(.[] | select(.name == $o) | .rect | "\(.width) \(.height)")')
+
+      # Not just empty: sway reports a disabled output with a zeroed rect, and
+      # a zero width collapses the column below to match nothing, which lands
+      # the TV on top of a real output.
+      if ! $test "$width" -gt 0 2> /dev/null
+      then
+        echo 'cast: could not read the new output back from sway' >&2
+        exit 1
+      fi
+      anchorX="$(echo "$outputs" | $jq -r --arg o "$output" \
+        'map(select(.active and .focused and .name != $o)) | .[0].rect.x // 0')"
+      topY="$(echo "$outputs" | $jq -r --arg o "$output" --argjson x "$anchorX" --argjson w "$width" \
+        'map(select(.active and .name != $o and .rect.x < ($x + $w) and (.rect.x + .rect.width) > $x) | .rect.y) | min // 0')"
+      $swaymsg "output $output position $anchorX $((topY - height))" > /dev/null
+
+      # Covers workspace 10's next creation only, so an existing one still has
+      # to be moved below.  Appends rather than replaces; sway skips names that
+      # no longer resolve.
+      $swaymsg "workspace 10 output $output" > /dev/null
+
+      # Focus it to move it -- an empty workspace cannot be named any other way.
+      # Gated, not chained: the switch fails under fullscreen-global, a chained
+      # list ignores that, and the move would take whatever is focused instead.
+      #
+      # Restoring by output, not by workspace: if the user was already on
+      # workspace 10, that name now resolves to the TV.
+      focusedOutput="$(echo "$outputs" | $jq -r --arg o "$output" \
+        'map(select(.active and .focused and .name != $o))[0].name // empty')"
+
+      if $swaymsg "workspace --no-auto-back-and-forth 10" > /dev/null
+      then
+        $swaymsg "move workspace to output $output" > /dev/null
+
+        # The move takes focus and the pointer with it.
+        if $test -n "$focusedOutput"
+        then
+          $swaymsg "focus output \"$focusedOutput\"" > /dev/null
+        fi
+      else
+        echo 'cast: could not move workspace 10 to the TV (fullscreen global?)' >&2
+      fi
+
       $systemctl --user start sunshine
       ;;
     *)
       $systemctl --user stop sunshine
+      unplug
       ;;
   esac
 ''

--- a/config/modules/ui/sunshine/default.nix
+++ b/config/modules/ui/sunshine/default.nix
@@ -1,51 +1,56 @@
-{config, ...}: let
+# See docs/casting-design.org for the reasoning behind the choices here.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
   # Sunshine's ports are offsets from its base port.
   mkPorts = map (offset: config.services.sunshine.settings.port + offset);
+
+  # Same generator and input as the upstream module's own config file, which it
+  # does not expose but the wrapper below has to name.
+  configFile = (pkgs.formats.keyValue {}).generate "sunshine.conf" config.services.sunshine.settings;
+
+  # `cast` names the output it just created, which is not knowable from the
+  # store.  Sunshine's `name=value` arguments override the config file.
+  sunshine-cast = pkgs.writeShellScript "sunshine-cast" ''
+    output="$(${pkgs.coreutils}/bin/cat "$XDG_RUNTIME_DIR/cast-output" 2>/dev/null)"
+
+    # A bare `output_name=` is a malformed argument, not an empty setting:
+    # Sunshine prints its help and returns 0, which systemd calls a clean start.
+    if ${pkgs.coreutils}/bin/test -z "$output"
+    then
+      echo 'sunshine: no cast output recorded -- start it with the `cast` launcher app' >&2
+      exit 1
+    fi
+
+    exec ${config.services.sunshine.package}/bin/sunshine ${configFile} output_name="$output"
+  '';
 in {
   services.sunshine = {
     enable = true;
 
-    # Sunshine captures the screen and injects input events, so it does not run
-    # for the whole session: the `cast` launcher app starts and stops it.
+    # It captures the screen and injects input, so `cast` starts and stops it
+    # rather than leaving it up for the session.
     autoStart = false;
 
-    # KMS capture reads planes that belong to another DRM master, which needs
-    # CAP_SYS_ADMIN; this grants it through a setcap wrapper.
-    capSysAdmin = true;
-
     settings = {
-      # sway is wlroots, but Sunshine's wlr-screencopy backend fails there:
-      # frame capture errors out on EGL image creation and the stream comes
-      # through as black with horizontal lines (LizardByte/Sunshine#5258).
-      # Grab the framebuffer from DRM/KMS instead.
-      #
-      # `output_name` is deliberately unset so Sunshine streams the default
-      # display: which output that should be depends on the kanshi profile in
-      # effect, and there is no stable answer to bake in here.
-      capture = "kms";
+      # KMS capture cannot see a headless output.  If the stream ever comes
+      # through black, see Sunshine#5258 in the design notes.
+      capture = "wlr";
 
-      # The web UI answers any LAN host by default; restrict it to local
-      # requests.  The `sunshine` launcher app opens it from this machine,
-      # which is the only place it is ever used from.  Note this rejects
-      # remote requests rather than changing what Sunshine binds: it still
-      # listens on every address, so the port stays closed below too.
+      # The web UI answers any LAN host by default.  This rejects remote
+      # requests; it does not change what Sunshine binds, so the port stays
+      # closed below too.
       origin_web_ui_allowed = "pc";
     };
   };
 
-  # This is `services.sunshine.openFirewall`'s own list with the web UI (offset
-  # +1) taken out, and it is written out here so that dropping it back in is
-  # visible in review.  That port is the one endpoint `origin_web_ui_allowed`
-  # does not cover: `savePassword` skips `authenticate` outright while no admin
-  # password is set, and the origin check lives inside `authenticate`, so
-  # between the first `cast` and finishing setup anything that can reach it can
-  # claim the account.  Everything else on these ports is either harmless to
-  # answer (`/serverinfo`, and `/pair`, which is gated on the PIN) or needs a
-  # paired client certificate.
-  #
-  # These are open on every interface, unlike the interface-scoped rules
-  # elsewhere in this repo: the laptop casts from wifi or the dock's ethernet
-  # depending on the day, and this also puts them on the tailnet.
+  systemd.user.services.sunshine.serviceConfig.ExecStart = lib.mkForce sunshine-cast;
+
+  # `openFirewall`'s own list minus the web UI at +1, which pairing does not
+  # gate.  Written out so re-adding it is visible in review.
   networking.firewall = {
     # -5 nvhttp HTTPS, 0 nvhttp HTTP, 21 RTSP.  (+1 is the web UI.)
     allowedTCPPorts = mkPorts [(-5) 0 21];
@@ -54,11 +59,6 @@ in {
     allowedUDPPorts = mkPorts [9 10 11 13 21];
   };
 
-  # Enabling Sunshine turns on Avahi publishing: the upstream module sets
-  # `services.avahi.publish.enable` and `.userServices`, and since nothing here
-  # defines either, its `mkDefault` takes effect.  That is what lets Moonlight
-  # discover the laptop by name, but it is system-wide and not tied to Sunshine
-  # running: lyra advertises its hostname and addresses on every network it
-  # joins from here on.  Setting `publish.enable = false` in the avahi module
-  # would override it, at the cost of adding the laptop to Moonlight by IP.
+  # Enabling Sunshine also turns on Avahi publishing system-wide, so lyra
+  # advertises itself wherever it goes.  That is what Moonlight discovers.
 }

--- a/docs/casting-design.org
+++ b/docs/casting-design.org
@@ -1,0 +1,84 @@
+* Casting: design notes
+
+Background for [[./casting.org][casting]].  Read this before changing
+[[../config/modules/ui/sunshine/default.nix][config/modules/ui/sunshine]] or [[../config/modules/ui/launcher/apps/cast.nix][the cast app]].
+
+** Why not Miracast
+
+Fire TV's "Display Mirroring" is Miracast, and every Linux sender needs Wi-Fi
+Direct through NetworkManager or wpa_supplicant.  This repo runs [[../config/modules/system/devices/wifi/default.nix][iwd]], which
+neither supports.  Sunshine also gets hardware encoding, audio and remote input.
+
+** Why a headless output, not a mirror
+
+The panel is 2880x1920 (3:2) and the TV is 16:9.  Sunshine never stretches --
+it pads to preserve aspect -- so mirroring can only letterbox.
+
+** Why wlr capture, and how to go back
+
+DRM/KMS capture reads planes off real hardware and cannot see a headless output.
+
+[[https://github.com/LizardByte/Sunshine/issues/5258][Sunshine#5258]] reports ~wlr~ failing on sway 1.12 for *physical* outputs: black
+with horizontal lines.  It does not reproduce on a headless output (checked
+against moonlight-qt).  If a version bump brings it back, that is the symptom.
+
+Reverting to mirroring means all three together: ~capture = "kms"~ with
+~capSysAdmin = true~, dropping the ~ExecStart~ override, and cutting ~cast~ back
+to starting and stopping the service.  The override alone refuses to start
+Sunshine once ~cast~ stops recording an output.
+
+** Sway's headless outputs are undocumented
+
+~create_output~ and ~output ... unplug~ appear nowhere in sway(5); both carry an
+"intended for developer use only" comment in sway's source.  A sway bump is the
+likeliest thing to break casting.
+
+~create_output~ takes no arguments and always adds a fresh ~HEADLESS-N~ at
+1920x1080, N counting up for the session.  So ~cast~ reads the name back from
+~swaymsg~, records it in ~$XDG_RUNTIME_DIR/cast-output~, and the unit's
+~ExecStart~ passes it to Sunshine as ~output_name=~, which overrides the config
+file.
+
+** Where the output is placed
+
+At the top of the focused output's column, so the pointer crosses onto it off
+the top edge.  Where a monitor is stacked above the laptop, the TV goes above
+that monitor.  Only outputs sharing that column set the height: taking the top
+of the whole layout instead leaves the TV touching a monitor at one corner in
+the profiles where the monitors sit beside the laptop, and sway will not cross
+a corner.
+
+** Why cast places workspace 10, not kanshi
+
+kanshi matches a profile only when its output count equals the number of
+connected heads, so it does nothing at all while the headless output exists.
+Covering it there would mean a second copy of every profile, keyed to a name
+that changes every cast.
+
+Two traps in the placement, both hit once already:
+
+- ~workspace 10~ fails under fullscreen-global, and a comma-chained command list
+  ignores that failure -- so the move must be gated on the switch succeeding, or
+  it throws whatever *is* focused onto the TV.
+- ~move workspace to output~ takes focus and the pointer with it, so both have
+  to be put back.
+
+** Why the firewall list is written out
+
+~openFirewall~ would also open the web UI (offset +1).  That port is the one
+thing ~origin_web_ui_allowed~ does not cover: ~savePassword~ skips
+~authenticate~ entirely while no admin password is set, so before setup
+anything that reaches it can claim the account.
+
+The remaining ports are open on *every* interface, tailnet included -- the only
+global rule written here, the rest being interface-scoped.  That is deliberate:
+the laptop casts from wifi or the dock's ethernet depending on the day.  Of
+what they expose, ~/serverinfo~ answers anyone and ~/pair~ is gated on the PIN;
+the rest needs a paired client certificate.
+
+** Side effect: mDNS
+
+Enabling Sunshine turns on Avahi publishing system-wide, which is what lets
+Moonlight find the laptop by name.  lyra then advertises itself on every network
+it joins.  ~publish.enable = false~ in the avahi module turns it off, at the
+cost of adding the laptop to Moonlight by IP.

--- a/docs/casting.org
+++ b/docs/casting.org
@@ -1,111 +1,62 @@
 * Casting the screen to a TV
 
-Screen casting is [[https://github.com/LizardByte/Sunshine][Sunshine]] on the
-laptop and [[https://moonlight-stream.org/][Moonlight]] on the TV.  Moonlight is
-a normal Fire TV app, so this works on a Fire TV without sideloading anything.
+[[https://github.com/LizardByte/Sunshine][Sunshine]] on the laptop, [[https://moonlight-stream.org/][Moonlight]] on the TV.  Moonlight is a normal
+Fire TV app, so nothing needs sideloading.
 
-Miracast is deliberately not used.  Fire TV's built-in "Display Mirroring" is
-Miracast, but every Linux implementation of the sending side needs Wi-Fi Direct
-through NetworkManager or wpa_supplicant, and this repo runs [[../config/modules/system/devices/wifi/default.nix][iwd]] with neither.
-Sunshine also gets hardware encoding, audio, and remote input, none of which
-Miracast would give us.
+See [[./casting-design.org][the design notes]] for why it is built this way, and what to check first
+when it breaks.
 
-** One-time setup
+** Setup
 
-*** 1. Create the state dataset, before deploying
+1. Create the state dataset, *before deploying* -- [[../config/machines/lyra/default.nix][lyra's config]] declares the
+   mount, so a boot without it fails:
 
-Sunshine keeps its web UI credentials and its paired client certificates in
-~~/.config/sunshine~.  ~/~ is a tmpfs on lyra, so that is a ZFS dataset.  Like
-every other dataset here it is mounted from ~fileSystems~ rather than by ZFS
-itself, so it needs a legacy mountpoint:
+   #+BEGIN_SRC bash
+     sudo zfs create -o mountpoint=legacy tank/persisted-state/sunshine
+   #+END_SRC
 
-#+BEGIN_SRC bash
-  sudo zfs create -o mountpoint=legacy tank/persisted-state/sunshine
-#+END_SRC
+2. ~cli deploy --on lyra~
 
-This has to come first: [[../config/machines/lyra/default.nix][lyra's config]] declares the mount, so once that is
-deployed a boot with no dataset behind it fails.
+3. Give the dataset to the user.  A new dataset's root is owned by root, and
+   nothing else fixes it -- without this Sunshine exits on every start:
 
-*** 2. Deploy
+   #+BEGIN_SRC bash
+     sudo chown cprussin:users /home/cprussin/.config/sunshine
+   #+END_SRC
 
-#+BEGIN_SRC bash
-  cli deploy --on lyra
-#+END_SRC
+4. Install "Moonlight Game Streaming" from the Amazon Appstore on the TV.
 
-*** 3. Give the dataset to the user
+5. Pair.  Run ~cast~, open ~sunshine~ in the launcher (localhost only,
+   self-signed cert), set a username and password.  Then open Moonlight, pick
+   the laptop (over mDNS, or by IP), and enter the PIN it shows into the web
+   UI.  Pairing survives reboots.
 
-A new dataset's root is owned by root, and ~install-user-mountpoints~ runs
-before the ZFS mounts, so nothing else fixes it.  Without this Sunshine cannot
-create its ~credentials/~ directory and exits immediately on every start:
+** Use
 
-#+BEGIN_SRC bash
-  sudo chown cprussin:users /home/cprussin/.config/sunshine
-#+END_SRC
+- ~cast~ starts and stops it.  Pick "Desktop" in Moonlight.
+- The TV is a second display, not a mirror: ~cast~ adds a 1920x1080 headless
+  output and Sunshine streams that.
+- It sits above your column, so the pointer reaches it off the top edge --
+  crossing any monitor stacked above the laptop on the way.
+- Workspace 10 moves onto it: ~Mod+asterisk~ focuses the TV,
+  ~Mod+Shift+asterisk~ throws a window there.
+- Moonlight sends keyboard, mouse and gamepad back, so the Fire TV remote drives
+  the laptop.  Only paired clients can.
+- Run ~presentation~ too.  Nothing else keeps the session awake -- the Fire TV
+  remote arrives as a gamepad, which libinput ignores -- and blanking kills the
+  stream.  ~cast~ leaves that to you: ~presentation~ also stops locking, on
+  suspend as well as on idle.
 
-*** 4. On the TV
+** Quirks
 
-Install "Moonlight Game Streaming" from the Amazon Appstore.
-
-*** 5. Pair
-
-Start Sunshine with ~cast~ in the launcher, then open its web UI with
-~sunshine~ in the launcher ([[https://localhost:47990]]).  That port is not
-opened in the firewall, so the web UI is reachable from this machine only.  It
-is served over HTTPS with a self-signed certificate, so the browser warning is
-expected.  Create the web UI username and password when it asks.
-
-Now open Moonlight on the TV.  It finds the laptop over mDNS if they are on the
-same network; otherwise add the laptop's IP by hand.  Select it, and Moonlight
-shows a PIN.  Enter that PIN under "PIN" in the Sunshine web UI.  Pairing
-survives reboots.
-
-** Casting
-
-Run ~cast~ in the launcher to start Sunshine, then pick "Desktop" in Moonlight.
-Run ~cast~ again to stop.
-
-Run ~presentation~ alongside it.  KMS capture reads a live output's framebuffer,
-so the stream drops once the screen blanks, and driving the laptop from the Fire
-TV remote does not keep the session awake: Moonlight sends the remote as a
-gamepad, Sunshine injects it as a virtual joystick, and libinput does not count
-joystick events as activity.  Only a mouse or keyboard on either end resets the
-idle timer.
-
-~cast~ deliberately does not do this itself.  ~presentation~ stops [[../config/modules/ui/swayidle/default.nix][swayidle]]
-outright, and swayidle owns the ~lock~ and ~before-sleep~ handlers as well as
-the idle timeouts -- so while it is off, ~loginctl lock-session~ does nothing
-and suspending no longer locks.  That is a deliberate thing to turn on, not
-something starting a cast should do quietly.
-
-** Notes
-
-- Sunshine streams the default display.  With several outputs connected that may
-  not be the one you want.  ~journalctl --user -u sunshine~ has a block like
-
-  #+BEGIN_EXAMPLE
-    -------- Start of KMS monitor list --------
-    Monitor 0 is eDP-1: BOE NE135A1M-NY1
-    --------- End of KMS monitor list ---------
-  #+END_EXAMPLE
-
-  and that monitor number goes in ~output_name~ in [[../config/modules/ui/sunshine/default.nix][config/modules/ui/sunshine]].
-  It is an index into Sunshine's own enumeration, assigned while walking
-  ~/dev/dri/card*~ and their active planes -- not a connector name.  So it can
-  move on a reboot, on plugging the dock in, or when a DisplayLink output shows
-  up, quite apart from a Sunshine version bump.  Check the log again rather than
-  trusting a number that worked last time.
-
-- The web UI's "Configuration" page cannot save anything.  Because
-  ~services.sunshine.settings~ is set, Sunshine runs against a config file in
-  the nix store -- change [[../config/modules/ui/sunshine/default.nix][config/modules/ui/sunshine]] and redeploy instead.  The
-  other pages do write: credentials, pairings, and the application list all live
-  in the dataset.  The "Desktop" entry Moonlight offers comes from the stock
-  ~apps.json~ Sunshine copies there on first start, and edits to it stick.
-
-- Moonlight sends keyboard, mouse, and gamepad input back, so the Fire TV remote
-  drives the laptop.  Nothing else on the network can: clients have to pair
-  first.
-
-- Capture is DRM/KMS rather than wlroots screencopy.  Sunshine's ~wlr~ backend
-  fails on sway 1.12: frame capture errors out on EGL image creation and the
-  stream arrives black with horizontal lines (LizardByte/Sunshine#5258).
+- The TV is above you and waybar is at the top of the screen, so overshooting a
+  waybar module puts the pointer -- and focus -- on a screen you cannot see.
+- Waybar draws on the TV too, so it shows up in the stream.
+- A spare empty workspace can appear on the TV alongside workspace 10.  It goes
+  away when the cast stops.
+- kanshi does nothing while a cast runs, so docking mid-cast will not rearrange
+  the screens.
+- A cast can end without ~cast~ (Sunshine fails, or ~systemctl~ stops it),
+  leaving the output behind.  The next ~cast~ clears it.
+- The web UI's "Configuration" page cannot save -- the config comes from the nix
+  store.  Credentials, pairings and the app list do save.


### PR DESCRIPTION
Follow-up to #31. The laptop panel is 2880x1920 (3:2) and the TV is 16:9, so mirroring can only letterbox or distort.

Sunshine itself never stretches — both scaling paths (`video.cpp:227` software, `graphics.cpp:789` GL/VAAPI) compute `fminf(out/in)` and centre with black padding. So the stretching on the TV was the client filling the bars, and the real problem is the aspect mismatch, not the stream.

## What changes

`cast` gives the TV an output of its own for the duration of the cast, rather than mirroring the panel:

- On start: `swaymsg create_output`, pin it to scale 1, record the name, move **workspace 10** onto it, start Sunshine.
- On stop: stop Sunshine, `output <name> unplug` — sway sends the workspace back to a real output.

So `Mod+asterisk` focuses the TV and `Mod+Shift+asterisk` throws a window onto it, using the existing bindings. **No keybindings change.**

### Why the workspace placement isn't in kanshi

It belongs there by rights, but kanshi can't see this output: `match_profile` takes a profile only when `wl_list_length(&profile->outputs) == wl_list_length(&state->heads)`. While the headless output exists, none of the six profiles match and kanshi does nothing at all. Covering it there would mean a duplicate of every profile keyed to a `HEADLESS-N` name that changes each cast. So `cast` does what the kanshi profiles do, where the name is known.

Note also that `workspace <name> output <output>` at runtime only records an assignment for future placement (`commands/workspace.c` just appends to `wsc->outputs`) — it does not move an existing workspace. Hence the explicit `move workspace to output`, with focus returned afterwards so a cast doesn't strand the cursor on a TV that's showing nothing yet.

### Two constraints worth knowing

**`create_output` takes no arguments.** Always a fresh 1920x1080 `HEADLESS-N`, N counting up, with no way to name or reuse one. So `cast` reads the name back from `swaymsg -t get_outputs`, writes it to `$XDG_RUNTIME_DIR/cast-output`, and the unit's `ExecStart` passes it as `output_name=` — Sunshine's `name=value` args override the config file (`config.cpp:1476`). Neither `create_output` nor `output … unplug` appears in sway(5) at all; the "developer use only" note is a source comment. A sway bump is the likeliest thing to break this.

**KMS capture can't see a headless output** — it reads planes off real hardware. So `capture` moves to `wlr`, and `capSysAdmin` goes away with it.

`cast` also unplugs the previous output before creating the next, not just on stop: a cast can end without going through `cast` (Sunshine failing leaves the unit `failed`; the `systemctl` app can stop it directly), and a leftover headless output holds a workspace, catches the pointer, and blocks every kanshi profile for the rest of the session.

## Testing

**Verified on hardware:** `wlr` capture of a headless output streams correctly end-to-end, tested with `moonlight-qt` against localhost. That was the open risk — [LizardByte/Sunshine#5258](https://github.com/LizardByte/Sunshine/issues/5258) reports the `wlr` backend failing on sway 1.12 for *physical* outputs, which is why #31 chose KMS; it does not reproduce on a headless output. The roll-back path is still recorded in the module comment in case that changes.

CI green. Not yet exercised against the Fire TV itself, and the workspace-10 placement postdates the capture test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oPrPoK4GJgFfT2E9qZsB1