### PR TITLE
[lyra] Suppress idle blanking from the cast itself

### DIFF
--- a/config/modules/ui/sunshine/default.nix
+++ b/config/modules/ui/sunshine/default.nix
@@ -25,7 +25,15 @@
       exit 1
     fi
 
-    exec ${config.services.sunshine.package}/bin/sunshine ${configFile} output_name="$output"
+    # Blanking takes the headless output down and nothing about a cast counts
+    # as activity -- Moonlight sends the Fire TV remote as a gamepad, which
+    # libinput ignores.  swayidle drops *both* its timeouts while logind
+    # reports an idle inhibitor -- the idle auto-lock as well as blanking --
+    # but keeps running, so the `lock` and `before-sleep` handlers still fire.
+    # Holding it here ties it to the process, so no exit path leaks it.
+    exec ${pkgs.systemd}/bin/systemd-inhibit --what=idle --who=cast \
+      --why='Casting the screen to a TV' \
+      ${config.services.sunshine.package}/bin/sunshine ${configFile} output_name="$output"
   '';
 in {
   services.sunshine = {

--- a/docs/casting-design.org
+++ b/docs/casting-design.org
@@ -22,10 +22,16 @@ DRM/KMS capture reads planes off real hardware and cannot see a headless output.
 with horizontal lines.  It does not reproduce on a headless output (checked
 against moonlight-qt).  If a version bump brings it back, that is the symptom.
 
-Reverting to mirroring means all three together: ~capture = "kms"~ with
-~capSysAdmin = true~, dropping the ~ExecStart~ override, and cutting ~cast~ back
-to starting and stopping the service.  The override alone refuses to start
-Sunshine once ~cast~ stops recording an output.
+Reverting to mirroring means all of: ~capture = "kms"~ with ~capSysAdmin =
+true~, dropping the ~output_name~ half of the ~ExecStart~ override, and cutting
+~cast~ back to starting and stopping the service.  That half alone refuses to
+start Sunshine once ~cast~ stops recording an output.
+
+Keep the ~systemd-inhibit~ wrapper -- blanking kills a mirrored stream too --
+but point it at ~${config.security.wrapperDir}/sunshine~.  ~capSysAdmin~ works
+by building a setcap wrapper and aiming the upstream ~ExecStart~ at it, so a
+wrapper that execs the store path directly leaves the option a no-op and KMS
+capture fails.
 
 ** Sway's headless outputs are undocumented
 
@@ -62,6 +68,30 @@ Two traps in the placement, both hit once already:
   it throws whatever *is* focused onto the TV.
 - ~move workspace to output~ takes focus and the pointer with it, so both have
   to be put back.
+
+** How blanking and the idle lock are suppressed
+
+Blanking kills the stream, and nothing about a cast counts as activity --
+Moonlight sends the Fire TV remote as a gamepad, and libinput ignores joystick
+events.
+
+Sunshine runs under ~systemd-inhibit --what=idle~.  swayidle watches logind's
+~BlockInhibited~ and drops its timeouts while an idle inhibitor is held, so
+blanking and the idle lock stop but the process stays up -- ~events.lock~ and
+~events.before-sleep~ keep working, which stopping the unit (what
+~presentation~ does) would not.  Tying it to Sunshine's own process means no
+exit path can leak it.
+
+A Wayland idle inhibitor would work too -- sway honours one on a mapped layer
+surface, which is how waybar's Presentation Mode module does it -- but it would
+need a client to own, and its lifetime would be that client's rather than
+Sunshine's.
+
+Casting therefore needs logind reachable, and ~systemd-inhibit~ refuses to run
+the command at all if ~Inhibit~ fails, so Sunshine would not start.  polkit
+allows ~inhibit-block-idle~ to anyone but must be running, and nothing here
+enables it directly: it comes in via ~security.rtkit.enable~ in [[../config/modules/system/devices/audio/default.nix][the audio
+module]] and via ~services.fwupd.enable~ (which also pulls in udisks2).
 
 ** Why the firewall list is written out
 

--- a/docs/casting.org
+++ b/docs/casting.org
@@ -42,10 +42,9 @@ when it breaks.
   ~Mod+Shift+asterisk~ throws a window there.
 - Moonlight sends keyboard, mouse and gamepad back, so the Fire TV remote drives
   the laptop.  Only paired clients can.
-- Run ~presentation~ too.  Nothing else keeps the session awake -- the Fire TV
-  remote arrives as a gamepad, which libinput ignores -- and blanking kills the
-  stream.  ~cast~ leaves that to you: ~presentation~ also stops locking, on
-  suspend as well as on idle.
+- Blanking *and* the idle auto-lock are suppressed for the duration -- nothing
+  about a cast counts as activity, so an idle inhibitor is held.  Locking by
+  hand and on suspend still work.
 
 ** Quirks
 
@@ -58,5 +57,9 @@ when it breaks.
   the screens.
 - A cast can end without ~cast~ (Sunshine fails, or ~systemctl~ stops it),
   leaving the output behind.  The next ~cast~ clears it.
+- Quitting Moonlight does not stop Sunshine, so the screen keeps not blanking
+  and not auto-locking until you run ~cast~ again.
+- waybar's Presentation Mode indicator still reads off during a cast; it tracks
+  a Wayland inhibitor, and this is a logind one.
 - The web UI's "Configuration" page cannot save -- the config comes from the nix
   store.  Credentials, pairings and the app list do save.


### PR DESCRIPTION
Follow-up to #32, which required running `presentation` by hand alongside `cast`. This removes that step.

## Why it wasn't coupled before

Blanking kills the stream, and nothing about a cast counts as activity — Moonlight sends the Fire TV remote as a gamepad and libinput ignores joystick events. So a cast does need the idle timers off.

But `presentation` stops the whole swayidle unit, and swayidle owns `events.lock` and `events.before-sleep` as well as the timers. Calling it from `cast` would have meant every cast silently left `loginctl lock-session` inert and the lid unlocked.

## What this does

Runs Sunshine under `systemd-inhibit --what=idle`.

swayidle already handles this: `need_logind` is true whenever a `lock` or `before-sleep` event is configured, so it connects to the bus and installs a `PropertiesChanged` listener; on `BlockInhibited` containing `idle` it calls `disable_timeouts()`, and `enable_timeouts()` refuses while an inhibitor is held. The process keeps running throughout, so the lock handlers are untouched.

Tying the inhibitor to Sunshine's own process means no exit path can leak it — crash, `systemctl stop`, start-limit failure all release it.

Nine lines in `config/modules/ui/sunshine/default.nix`; `cast`, `presentation` and the swayidle module are unchanged.

## Alternative considered

A *Wayland* idle inhibitor is the obvious approach and doesn't work here: sway's `check_active` returns `view && view->container && view_is_visible(view)`, so an inhibitor on a surface with no view is inactive — and a headless inhibitor client (`wlinhibit`) creates nothing else.

An earlier revision of this PR split swayidle into separate handler and timer units so `cast` could stop just the timers. Review found that leaves the timers off indefinitely if a cast ends any way other than through `cast`, and that it also breaks swayidle's own logind-inhibit awareness. The inhibitor does the same job with no state to leak.

## Testing

CI only. Worth confirming on the laptop that during a cast the screen stops blanking while `loginctl lock-session` and lid-close still lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oPrPoK4GJgFfT2E9qZsB1