### PR TITLE
[lyra] Cast at the TV's native resolution

### DIFF
--- a/config/modules/ui/launcher/apps/cast.nix
+++ b/config/modules/ui/launcher/apps/cast.nix
@@ -12,6 +12,8 @@ writeShellScript "cast" ''
   comm=${coreutils}/bin/comm
   head=${coreutils}/bin/head
   rm=${coreutils}/bin/rm
+  seq=${coreutils}/bin/seq
+  sleep=${coreutils}/bin/sleep
   sort=${coreutils}/bin/sort
   test=${coreutils}/bin/test
   grep=${gnugrep}/bin/grep
@@ -20,6 +22,14 @@ writeShellScript "cast" ''
   jq=${jq}/bin/jq
 
   outputFile="$XDG_RUNTIME_DIR/cast-output"
+
+  # The TV.  `create_output` hardcodes 1920x1080, and Sunshine captures the
+  # output's mode rather than its logical size, so this is what gets encoded --
+  # leave it at the default and a 4K client just upscales 1080p.  Scale 2 keeps
+  # the desktop readable from a couch and leaves the logical size at 1920x1080,
+  # which is what the positioning below works in.
+  mode=3840x2160
+  scale=2
 
   # Headless only: a monitor plugged in between the two samples below would
   # otherwise land in the diff, and everything downstream takes a single name.
@@ -62,23 +72,50 @@ writeShellScript "cast" ''
       # Record before anything else can fail.
       echo "$output" > "$outputFile"
 
-      # 1:1 on a 1080p TV.
-      $swaymsg "output $output scale 1" > /dev/null
+      # swaymsg reports command errors on stdout, and as JSON rather than prose
+      # when it is not a tty.  Keep them: the failure below otherwise points at
+      # a sway log that has nothing in it.
+      if ! error="$($swaymsg "output $output mode --custom $mode scale $scale" 2>&1)"
+      then
+        echo "cast: $(echo "$error" | $jq -r '.[].error? // .' 2> /dev/null || echo "$error")" >&2
+        exit 1
+      fi
 
-      # At the top of the focused output's column, so the pointer reaches the TV
-      # off the top edge.  Only that column counts -- see the design notes.
-      outputs="$($swaymsg -t get_outputs)"
+      # The modeset runs behind a timer, and one that cannot be allocated drops
+      # back to the old mode while keeping the new scale -- a quarter-size
+      # desktop the client then upscales, which is the bug this is fixing
+      # wearing a disguise.  Wait for the mode, which also settles the rect the
+      # positioning below reads.
+      for _ in $($seq 50)
+      do
+        outputs="$($swaymsg -t get_outputs)"
+        current="$(echo "$outputs" | $jq -r --arg o "$output" \
+          'first(.[] | select(.name == $o) | "\(.current_mode.width)x\(.current_mode.height)")')"
+        $test "$current" = "$mode" && break
+        $sleep 0.02
+      done
+
+      if $test "$current" != "$mode"
+      then
+        echo "cast: $output came up ''${current:-nothing}, not $mode" >&2
+        exit 1
+      fi
+
       read -r width height < <(echo "$outputs" | $jq -r --arg o "$output" \
         'first(.[] | select(.name == $o) | .rect | "\(.width) \(.height)")')
 
-      # Not just empty: sway reports a disabled output with a zeroed rect, and
-      # a zero width collapses the column below to match nothing, which lands
-      # the TV on top of a real output.
+      # Belt and braces: the mode check above should already have caught every
+      # way this can come back empty, `0` or `null`.  Any of them would abort
+      # jq at `--argjson w` or collapse the column below to match nothing,
+      # landing the TV on a real output.
       if ! $test "$width" -gt 0 2> /dev/null
       then
-        echo 'cast: could not read the new output back from sway' >&2
+        echo "cast: $output reports no size; is it still enabled?" >&2
         exit 1
       fi
+
+      # At the top of the focused output's column, so the pointer reaches the TV
+      # off the top edge.  Only that column counts -- see the design notes.
       anchorX="$(echo "$outputs" | $jq -r --arg o "$output" \
         'map(select(.active and .focused and .name != $o)) | .[0].rect.x // 0')"
       topY="$(echo "$outputs" | $jq -r --arg o "$output" --argjson x "$anchorX" --argjson w "$width" \

--- a/docs/casting-design.org
+++ b/docs/casting-design.org
@@ -40,10 +40,10 @@ capture fails.
 likeliest thing to break casting.
 
 ~create_output~ takes no arguments and always adds a fresh ~HEADLESS-N~ at
-1920x1080, N counting up for the session.  So ~cast~ reads the name back from
-~swaymsg~, records it in ~$XDG_RUNTIME_DIR/cast-output~, and the unit's
-~ExecStart~ passes it to Sunshine as ~output_name=~, which overrides the config
-file.
+1920x1080 (~cast~ then sets the mode; see below), N counting up for the
+session.  So ~cast~ reads the name back from ~swaymsg~, records it in
+~$XDG_RUNTIME_DIR/cast-output~, and the unit's ~ExecStart~ passes it to
+Sunshine as ~output_name=~, which overrides the config file.
 
 ** Where the output is placed
 
@@ -53,6 +53,23 @@ that monitor.  Only outputs sharing that column set the height: taking the top
 of the whole layout instead leaves the TV touching a monitor at one corner in
 the profiles where the monitors sit beside the laptop, and sway will not cross
 a corner.
+
+** Why the output is 3840x2160 at scale 2
+
+Sunshine captures the mode, not the logical size, so the mode sets the stream's
+ceiling -- left at ~create_output~'s 1920x1080 a 4K client just upscales.  Scale
+2 keeps the desktop readable from a couch and holds the logical size at
+1920x1080, which is what the placement arithmetic works in.
+
+Sway composites that continuously and Sunshine encodes it, so a cast costs
+roughly four times the GPU of the 1080p path.  If the stream falls apart, check
+Sunshine's log for the encoder it picked: the software fallback cannot hold
+4K60.
+
+~cast~ waits for the mode rather than assuming it: the modeset is deferred, so
+~swaymsg~ returns success before it happens, and one that cannot be allocated
+drops the mode while keeping the scale -- a quarter-size desktop the client
+upscales, which looks exactly like the bug the mode is here to fix.
 
 ** Why cast places workspace 10, not kanshi
 

--- a/docs/casting.org
+++ b/docs/casting.org
@@ -34,8 +34,13 @@ when it breaks.
 ** Use
 
 - ~cast~ starts and stops it.  Pick "Desktop" in Moonlight.
-- The TV is a second display, not a mirror: ~cast~ adds a 1920x1080 headless
-  output and Sunshine streams that.
+- The TV is a second display, not a mirror: ~cast~ adds a headless output and
+  Sunshine streams that.
+- It is 3840x2160 at scale 2 -- Sunshine captures the output's *mode*, so that
+  is the ceiling on the stream; what actually goes out is whatever Moonlight
+  asks for.  Set Moonlight to 4K and HEVC, with the bitrate raised to match.
+  If it stutters, drop Moonlight back to 1080p: the capture stays 4K and
+  downscales, so nothing else has to change.
 - It sits above your column, so the pointer reaches it off the top edge --
   crossing any monitor stacked above the laptop on the way.
 - Workspace 10 moves onto it: ~Mod+asterisk~ focuses the TV,


### PR DESCRIPTION
The stream to the TV was 1080p on a 4K panel.

## Cause

`swaymsg create_output` hardcodes 1920x1080 and nothing set a mode afterwards. Sunshine's wlr capture takes its dimensions from the `wl_output.mode` event — the output's *mode*, not its logical size (`wayland.cpp` fills `viewport.width/height` from `wl_mode` and `logical_*` from `xdg_size` separately; `wlgrab` uses the former for the encode device). So the encode was 1080p and Moonlight upscaled it.

## Fix

`output <name> mode --custom 3840x2160 scale 2`.

- **mode** is what Sunshine captures, so this is the change that matters.
- **scale 2** keeps the desktop readable at couch distance and holds the logical size at 1920x1080 — which is what the positioning arithmetic further down works in, so that is untouched.
- **`--custom`** rather than relying on `set_mode` taking the custom path because the modes list happens to be empty.

The two values are shell variables at the top of `cast`, since they describe the TV rather than the mechanism.

### Verifying the modeset

Two failure modes made a naive version of this unsafe, both found in review:

- The modeset is **deferred** behind a timer, so `swaymsg` returns success before it happens — and the `get_outputs` read the positioning depends on was racing it.
- A modeset that **can't be allocated** drops the mode but *keeps* the scale (`search_valid_config`, `sway/config/output.c:873`), giving a 960x540 logical desktop and a 1080p encode. That is the original bug in disguise, and nothing would have reported it.

So `cast` polls `get_outputs` until `current_mode` matches, and fails naming what it got. That settles the rect for the positioning too. It also captures the mode command's own output — `swaymsg` reports command errors on *stdout*, as JSON when not a tty — so a rejected command says why instead of pointing at a sway log with nothing in it.

## Also needed, on the Fire TV

Moonlight has to be set to **4K** and **HEVC**, with the **bitrate raised** to match. Left at 1080p it just downscales this again. If it stutters, dropping Moonlight back to 1080p costs nothing — the capture stays 4K and downscales. In `docs/casting.org`.

## Cost

Sway composites 4K60 continuously while a cast runs and Sunshine encodes it — roughly 4x the GPU of the 1080p path. The software encoder cannot hold 4K60, so if the stream falls apart, check which encoder Sunshine picked. In `docs/casting-design.org`.

## Testing

CI. Untested against the TV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oPrPoK4GJgFfT2E9qZsB1