### PR TITLE
[lyra] Do not let the cast resolution be fatal to the cast

### DIFF
--- a/config/modules/ui/launcher/apps/cast.nix
+++ b/config/modules/ui/launcher/apps/cast.nix
@@ -6,6 +6,7 @@
   systemd,
   sway,
   jq,
+  notify-send,
 }:
 writeShellScript "cast" ''
   cat=${coreutils}/bin/cat
@@ -20,8 +21,18 @@ writeShellScript "cast" ''
   systemctl=${systemd}/bin/systemctl
   swaymsg=${sway}/bin/swaymsg
   jq=${jq}/bin/jq
+  notifySend=${notify-send}/bin/notify-send
 
   outputFile="$XDG_RUNTIME_DIR/cast-output"
+
+  # The launcher discards stderr, so a warning only reaches the user as a
+  # notification.  `--` because swaymsg's errors come through here: notify-send
+  # rejects a message starting with `-` and says so on stdout, which the
+  # launcher discards too.
+  warn() {
+    echo "cast: $1" >&2
+    $notifySend -i video-display -- Cast "$1"
+  }
 
   # The TV.  `create_output` hardcodes 1920x1080, and Sunshine captures the
   # output's mode rather than its logical size, so this is what gets encoded --
@@ -65,62 +76,64 @@ writeShellScript "cast" ''
 
       if $test -z "$output"
       then
-        echo 'cast: sway added no output; check the sway log' >&2
+        warn 'sway added no output; check the sway log'
         exit 1
       fi
 
       # Record before anything else can fail.
       echo "$output" > "$outputFile"
 
+      # From here to `start sunshine` nothing is fatal: casting at the wrong
+      # resolution, or with the TV in the wrong place, beats not casting.
+
       # swaymsg reports command errors on stdout, and as JSON rather than prose
-      # when it is not a tty.  Keep them: the failure below otherwise points at
-      # a sway log that has nothing in it.
+      # when it is not a tty.
+      modeset=yes
       if ! error="$($swaymsg "output $output mode --custom $mode scale $scale" 2>&1)"
       then
-        echo "cast: $(echo "$error" | $jq -r '.[].error? // .' 2> /dev/null || echo "$error")" >&2
-        exit 1
+        modeset=no
+        warn "$(echo "$error" | $jq -r '.[].error? // .' 2> /dev/null || echo "$error")"
       fi
 
       # The modeset runs behind a timer, and one that cannot be allocated drops
       # back to the old mode while keeping the new scale -- a quarter-size
       # desktop the client then upscales, which is the bug this is fixing
       # wearing a disguise.  Wait for the mode, which also settles the rect the
-      # positioning below reads.
+      # positioning below reads.  A single pass when the command itself failed:
+      # nothing is on its way, and it has already been reported.
       for _ in $($seq 50)
       do
         outputs="$($swaymsg -t get_outputs)"
         current="$(echo "$outputs" | $jq -r --arg o "$output" \
           'first(.[] | select(.name == $o) | "\(.current_mode.width)x\(.current_mode.height)")')"
         $test "$current" = "$mode" && break
+        $test "$modeset" = no && break
         $sleep 0.02
       done
 
-      if $test "$current" != "$mode"
+      if $test "$modeset" = yes && $test "$current" != "$mode"
       then
-        echo "cast: $output came up ''${current:-nothing}, not $mode" >&2
-        exit 1
+        warn "$output came up ''${current:-nothing}, not $mode"
       fi
 
       read -r width height < <(echo "$outputs" | $jq -r --arg o "$output" \
         'first(.[] | select(.name == $o) | .rect | "\(.width) \(.height)")')
 
-      # Belt and braces: the mode check above should already have caught every
-      # way this can come back empty, `0` or `null`.  Any of them would abort
-      # jq at `--argjson w` or collapse the column below to match nothing,
-      # landing the TV on a real output.
-      if ! $test "$width" -gt 0 2> /dev/null
+      # Positioning needs a size; without one, jq would abort at `--argjson w`
+      # or match nothing and land the TV on a real output.  Leave it where sway
+      # put it instead -- off to the right, reachable, just not overhead.
+      if $test "$width" -gt 0 2> /dev/null
       then
-        echo "cast: $output reports no size; is it still enabled?" >&2
-        exit 1
+        # At the top of the focused output's column, so the pointer reaches the
+        # TV off the top edge.  Only that column counts -- see the design notes.
+        anchorX="$(echo "$outputs" | $jq -r --arg o "$output" \
+          'map(select(.active and .focused and .name != $o)) | .[0].rect.x // 0')"
+        topY="$(echo "$outputs" | $jq -r --arg o "$output" --argjson x "$anchorX" --argjson w "$width" \
+          'map(select(.active and .name != $o and .rect.x < ($x + $w) and (.rect.x + .rect.width) > $x) | .rect.y) | min // 0')"
+        $swaymsg "output $output position $anchorX $((topY - height))" > /dev/null
+      else
+        warn "$output reports no size; leaving it where sway put it"
       fi
-
-      # At the top of the focused output's column, so the pointer reaches the TV
-      # off the top edge.  Only that column counts -- see the design notes.
-      anchorX="$(echo "$outputs" | $jq -r --arg o "$output" \
-        'map(select(.active and .focused and .name != $o)) | .[0].rect.x // 0')"
-      topY="$(echo "$outputs" | $jq -r --arg o "$output" --argjson x "$anchorX" --argjson w "$width" \
-        'map(select(.active and .name != $o and .rect.x < ($x + $w) and (.rect.x + .rect.width) > $x) | .rect.y) | min // 0')"
-      $swaymsg "output $output position $anchorX $((topY - height))" > /dev/null
 
       # Covers workspace 10's next creation only, so an existing one still has
       # to be moved below.  Appends rather than replaces; sway skips names that
@@ -132,21 +145,23 @@ writeShellScript "cast" ''
       # list ignores that, and the move would take whatever is focused instead.
       #
       # Restoring by output, not by workspace: if the user was already on
-      # workspace 10, that name now resolves to the TV.
+      # workspace 10, that name now resolves to the TV.  Nowhere to restore to
+      # means not taking focus at all -- by here the TV may have no size and no
+      # position, and focus would be stranded somewhere unseen.
       focusedOutput="$(echo "$outputs" | $jq -r --arg o "$output" \
         'map(select(.active and .focused and .name != $o))[0].name // empty')"
 
-      if $swaymsg "workspace --no-auto-back-and-forth 10" > /dev/null
+      if $test -z "$focusedOutput"
+      then
+        warn 'cannot tell what is focused; leaving workspace 10 where it is'
+      elif $swaymsg "workspace --no-auto-back-and-forth 10" > /dev/null
       then
         $swaymsg "move workspace to output $output" > /dev/null
 
         # The move takes focus and the pointer with it.
-        if $test -n "$focusedOutput"
-        then
-          $swaymsg "focus output \"$focusedOutput\"" > /dev/null
-        fi
+        $swaymsg "focus output \"$focusedOutput\"" > /dev/null
       else
-        echo 'cast: could not move workspace 10 to the TV (fullscreen global?)' >&2
+        warn 'could not move workspace 10 to the TV (fullscreen global?)'
       fi
 
       $systemctl --user start sunshine

--- a/docs/casting-design.org
+++ b/docs/casting-design.org
@@ -45,6 +45,19 @@ session.  So ~cast~ reads the name back from ~swaymsg~, records it in
 ~$XDG_RUNTIME_DIR/cast-output~, and the unit's ~ExecStart~ passes it to
 Sunshine as ~output_name=~, which overrides the config file.
 
+** Only failing to get an output is fatal
+
+Everything after that -- the mode, the placement, workspace 10 -- warns where it
+can and carries on: casting at the wrong size, or with the TV somewhere
+unhelpful, beats not casting.  Warnings go through ~notify-send~, since the
+launcher discards stderr.
+
+Two are skipped rather than attempted.  Positioning, when the output reports no
+size to position by.  And the workspace move, when ~cast~ cannot read what is
+focused: it takes focus to name an empty workspace, and with nowhere to hand
+focus back it would strand it on an output that by then may have neither size
+nor position.
+
 ** Where the output is placed
 
 At the top of the focused output's column, so the pointer crosses onto it off

--- a/docs/casting.org
+++ b/docs/casting.org
@@ -60,6 +60,11 @@ when it breaks.
   away when the cast stops.
 - kanshi does nothing while a cast runs, so docking mid-cast will not rearrange
   the screens.
+- Once the output exists, nothing stops a cast: the TV can come up the wrong
+  size, sit off to the right instead of overhead, or not take workspace 10.
+  ~cast~ warns about the mode and the workspace switch; the commands that place
+  the TV and hand it workspace 10 discard their status, so those failures pass
+  silently.
 - A cast can end without ~cast~ (Sunshine fails, or ~systemctl~ stops it),
   leaving the output behind.  The next ~cast~ clears it.
 - Quitting Moonlight does not stop Sunshine, so the screen keeps not blanking


### PR DESCRIPTION
Everything between creating the headless output and starting Sunshine could `exit 1` — a modeset that did not take, a rect that could not be read. A 4K mode that failed to allocate meant no cast at all, and the message went to stderr, which the launcher discards, so `cast` just appeared to do nothing.

- Warn and carry on. Only failing to get an output at all is still fatal.
- Warnings go through `notify-send`, like the other launcher apps — stderr is where the last one went to die.
- Positioning is skipped when there is no size to position by. So is the workspace move when `cast` cannot read what is focused: it takes focus to name an empty workspace, and with nowhere to hand focus back it would strand focus on an output that may by then have neither size nor position.
- A modeset that fails outright no longer falls into the poll loop, where it waited out all 50 iterations for a mode that was never coming and then restated the error it had already printed.

**Not** the fix for the Fire TV discovery problem — Sunshine is up and its web UI loads there, so none of these paths fired. Robustness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oPrPoK4GJgFfT2E9qZsB1