### PR TITLE
Add gdrive launcher app

### DIFF
--- a/config/modules/ui/launcher/default.nix
+++ b/config/modules/ui/launcher/default.nix
@@ -68,6 +68,7 @@ in {
           email = mkGoogleApp "gmail" "https://mail.google.com";
           eyes = mkWebApp "eyes" "https://eyes.internal.prussin.net";
           firefox = pkgs.writeShellScript "firefox" "${pkgs.launcher}/bin/browse --browser firefox $*";
+          gdrive = mkGoogleApp "gdrive" "https://drive.google.com";
           gimp = "${pkgs.gimp}/bin/gimp";
           home = mkWebApp "home" "https://home-assistant.internal.prussin.net";
           journal = mkTerminalApp "journal" "sudo ${pkgs.systemd}/bin/journalctl -alf";


### PR DESCRIPTION
Adds a `gdrive` launcher entry pointing at https://drive.google.com via `mkGoogleApp`, so it picks up the same per-account `authuser` handling as `calendar` and `email`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZk8tyycB5eveTg3zQUvaH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZk8tyycB5eveTg3zQUvaH)_