### PR TITLE
Pin crux's dynamic DNS record to a 60s TTL and check minutely

### DIFF
--- a/config/machines/crux/cloudflare-dyndns-ttl.patch
+++ b/config/machines/crux/cloudflare-dyndns-ttl.patch
@@ -1,0 +1,30 @@
+Pin the record TTL to 60s instead of Cloudflare's "Auto".
+
+cloudflare-dyndns hardcodes `"ttl": 1` -- Cloudflare's sentinel for "Auto",
+which is 300s for a non-proxied record -- and omits `ttl` entirely from the
+update PUT.  Since Cloudflare treats that PUT as a full replacement, a record
+created at any other TTL is reset to Auto on the next update, so both payloads
+have to be pinned, not just the create.
+
+Upstream exposes no option for this, so there is nothing to configure our way
+out of; 60s is Cloudflare's floor for an explicit TTL.
+
+--- a/cloudflare_dyndns/cloudflare.py
++++ b/cloudflare_dyndns/cloudflare.py
+@@ -92,7 +92,7 @@
+             "name": domain,
+             "type": record_type,
+             "content": str(ip),
+-            "ttl": 1,
++            "ttl": 60,
+             "proxied": proxied,
+         }
+         try:
+@@ -120,6 +120,7 @@
+             "name": domain,
+             "type": record_type,
+             "content": str(ip),
++            "ttl": 60,
+             "proxied": proxied,
+         }
+         try:

--- a/config/machines/crux/dynamic-dns.nix
+++ b/config/machines/crux/dynamic-dns.nix
@@ -4,6 +4,18 @@
   ...
 }: let
   passwords = pkgs.callPackage ../../../lib/passwords.nix {};
+
+  # crux's address is what every WireGuard peer and inbound service resolves,
+  # so the record wants a short TTL -- but cloudflare-dyndns publishes
+  # Cloudflare's "Auto" (~300s) and exposes no knob for it.  Neither does any
+  # other DDNS client packaged in nixpkgs: ddclient's `cloudflare` protocol
+  # declares no `ttl` config var, and while inadyn's does, its cache file is
+  # keyed on the plugin name, so the A and AAAA provider blocks would share one
+  # cache and rewrite each other's record every run.  Patching this one is the
+  # smaller lie.
+  cloudflare-dyndns = pkgs.cloudflare-dyndns.overrideAttrs (old: {
+    patches = (old.patches or []) ++ [./cloudflare-dyndns-ttl.patch];
+  });
 in {
   deployment.keys.cloudflare-dyndns-api-token = {
     keyCommand = passwords.getPassword "Connor/Infrastructure/cloudflare/dynamic-dns";
@@ -12,8 +24,13 @@ in {
 
   services.cloudflare-dyndns = {
     enable = true;
+    package = cloudflare-dyndns;
     domains = ["crux.prussin.net"];
     apiTokenFile = config.deployment.keys.cloudflare-dyndns-api-token.path;
+    # Paired with the 60s TTL above, this bounds a move at about two minutes.
+    # It costs two requests a minute to api.ipify.org: the address lookup runs
+    # before the cache comparison, so it happens whether or not the IP moved.
+    frequency = "minutely";
     ipv6 = true;
   };
 


### PR DESCRIPTION
Recovery from a WAN address change was bounded at ~10 minutes: 5 for the timer to notice, plus 5 of TTL. This moves both halves, to ~2 minutes.

**The timer** is `frequency = "minutely"`. It costs two requests a minute to api.ipify.org — cloudflare-dyndns looks the address up *before* consulting its cache, so it pays that whether or not anything moved. That's why the cadence was left at the default when this was first written; it's a fair price for the latency.

**The TTL** is the hard half, because nothing in nixpkgs will set it for a Cloudflare record:

| client | TTL knob? | |
|---|---|---|
| `cloudflare-dyndns` | no | hardcodes `"ttl": 1` (Auto ≈ 300s) on create, omits `ttl` from the update PUT — which Cloudflare treats as a full replacement, so it resets to Auto |
| `ddclient` | no | its `cloudflare` protocol declares only `login`, `min-interval`, `server`, `zone` — no `ttl`, unlike a dozen of its other protocols |
| `inadyn` | yes, but | see below |

inadyn looked like the answer — `ttl` is first-class in its cloudflare plugin and its NixOS module already defaults to a minutely timer — but it can't do dual-stack Cloudflare. Its cache file is keyed on the *plugin* name (`src/cache.c:119`), and Cloudflare has only `default@cloudflare.com`, so the A block and the AAAA block share one cache file. Each run, one reads the other's address, concludes the IP changed, and rewrites its record — a spurious write every minute, forever, with change detection defeated. inadyn's dual-stack model assumes a separate `ipv6@…` plugin, which it detects by name (`cache.c:189`).

So this patches cloudflare-dyndns, which already gets dual-stack right off a single cache. Both payloads are pinned, not just the create, for the full-replacement reason above.

## Deploy

No new secret — same `Connor/Infrastructure/cloudflare/dynamic-dns` token, unchanged permissions. Just `cli deploy`.

Existing records keep their current TTL until the next update writes one; the first run after deploy will do that.

Co-Authored-By: Connor Prussin <connor@prussin.net>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQuM4jtjNPGeN3LGHP15WX

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQuM4jtjNPGeN3LGHP15WX)_