### PR TITLE
Move crux's dynamic DNS to inadyn for a 60s TTL and minutely checks

### DIFF
--- a/config/machines/crux/dynamic-dns.nix
+++ b/config/machines/crux/dynamic-dns.nix
@@ -4,21 +4,80 @@
   ...
 }: let
   passwords = pkgs.callPackage ../../../lib/passwords.nix {};
+
+  # The v6 plugin is a clone of the v4 one, so it inherits a checkip of
+  # Cloudflare's `1.1.1.1` while forcing its own traffic over v6 -- it has to
+  # be told where to look instead.  A command rather than a `checkip-server`
+  # because `get_address_backend` returns straight out of the command branch
+  # (`src/ddns.c:463`), while the server branch falls back to plaintext
+  # `http://ifconfig.me/ip` when it can't reach its server, and the connection
+  # only prefers v6 rather than requiring it.  So a v6 outage under a
+  # `checkip-server` ends with the v6 block holding a v4 address, and since the
+  # record type is chosen from the address, it would then write that over the A
+  # record and cache it as the AAAA.  A failing command just yields no address
+  # and no update, which is what we want.
+  #
+  # `+time`/`+tries` because inadyn reads the command's output with an untimed
+  # `popen` (`src/ddns.c:90`), so the only bound on a stalled lookup is
+  # systemd's 90s start timeout -- which would fail the unit rather than skip
+  # the cycle.  This caps dig's own query at 3s rather than the default 5s x 3;
+  # the forward lookup of `ns1.google.com` is a `getaddrinfo` outside dig's
+  # event loop and stays bounded only by resolv.conf.
+  public-ipv6 = pkgs.writeShellScript "public-ipv6" ''
+    set -euo pipefail
+    ${pkgs.dnsutils}/bin/dig -6 TXT +short +time=3 +tries=1 \
+      o-o.myaddr.l.google.com @ns1.google.com \
+      | ${pkgs.gnused}/bin/sed 's/"//g'
+  '';
+
+  # `username` is the zone, not a login -- the token in `include` is the whole
+  # credential.
+  #
+  # `ttl` and `proxied` share one buffer in inadyn's cloudflare plugin and the
+  # second write clobbers the first, so only `ttl` is set here.  Omitting
+  # `proxied` leaves it alone rather than setting it false, since the update is
+  # a PATCH -- which is fine, the record is unproxied and has to stay that way
+  # because crux.prussin.net is the WireGuard endpoint.
+  #
+  # 60 is Cloudflare's floor for an explicit TTL; the alternative is its
+  # "Auto", which is 300s.  Paired with the module's minutely timer that bounds
+  # recovery from a WAN address change at about two minutes.
+  cloudflare = {
+    username = "prussin.net";
+    hostname = "crux.prussin.net";
+    ttl = 60;
+    include = config.deployment.keys.inadyn-cloudflare-api-token.path;
+  };
 in {
-  deployment.keys.cloudflare-dyndns-api-token = {
-    keyCommand = passwords.getPassword "Connor/Infrastructure/cloudflare/dynamic-dns";
+  deployment.keys.inadyn-cloudflare-api-token = {
+    inherit (config.users.users.inadyn) group;
+    user = config.users.users.inadyn.name;
+    keyCommand = passwords.getInadynSecrets "Connor/Infrastructure/cloudflare/dynamic-dns";
     destDir = "/secrets";
   };
 
-  services.cloudflare-dyndns = {
+  services.inadyn = {
     enable = true;
-    domains = ["crux.prussin.net"];
-    apiTokenFile = config.deployment.keys.cloudflare-dyndns-api-token.path;
-    ipv6 = true;
+    settings = {
+      # Without this a record edited by hand -- or one left at Auto by the
+      # previous client -- is never corrected, since inadyn only writes on a
+      # change it observes and never re-reads the record.  Daily is cheap next
+      # to the minutely no-ops.
+      forced-update = 86400;
+
+      provider = {
+        "default@cloudflare.com" = cloudflare;
+        "ipv6@cloudflare.com" =
+          cloudflare
+          // {
+            checkip-command = "${public-ipv6}";
+          };
+      };
+    };
   };
 
-  systemd.services.cloudflare-dyndns = {
-    after = ["cloudflare-dyndns-api-token-key.service"];
-    requires = ["cloudflare-dyndns-api-token-key.service"];
+  systemd.services.inadyn = {
+    after = ["inadyn-cloudflare-api-token-key.service"];
+    requires = ["inadyn-cloudflare-api-token-key.service"];
   };
 }

--- a/lib/passwords.nix
+++ b/lib/passwords.nix
@@ -67,6 +67,11 @@
     echo "CLIENT_ID=$(${getPasswordField}/bin/getPasswordField "$1" "Client ID")"
     echo "PROJECT_ID=$(${getPasswordField}/bin/getPasswordField "$1" "Project ID")"
   '';
+
+  getInadynSecrets = pkgs.writeShellScriptBin "getInadynSecrets" ''
+    set -euo pipefail
+    echo "password = \"$(${getPassword}/bin/getPassword "$1")\""
+  '';
 in {
   passwordUtils = pkgs.symlinkJoin {
     name = "passwordUtils";
@@ -80,6 +85,7 @@ in {
       getVaultwardenSecrets
       getGmailNewMailCounterEnvFile
       getImmichSecrets
+      getInadynSecrets
     ];
   };
   getPassword = name: ["getPassword" name];
@@ -97,4 +103,5 @@ in {
     );
   getGmailNewMailCounterEnvFile = name: ["getGmailNewMailCounterEnvFile" name];
   getImmichSecrets = db: ["getImmichSecrets" db];
+  getInadynSecrets = name: ["getInadynSecrets" name];
 }

--- a/systems-test.nix
+++ b/systems-test.nix
@@ -186,7 +186,7 @@ in
     check "dns forwarding is working" check_forwarded_dns
 
     check_dynamic_dns() {
-        expect_healthy_timer cloudflare-dyndns || return 1
+        expect_healthy_timer inadyn || return 1
         local a aaaa
         a=$($dig +short A crux.prussin.net)
         aaaa=$($dig +short AAAA crux.prussin.net)


### PR DESCRIPTION
Recovery from a WAN address change was bounded at ~10 minutes: 5 for the timer to notice, plus 5 of TTL. Both halves move here, to ~2 minutes.

Supersedes #39, which patched cloudflare-dyndns to pin the TTL. That patch rested on a wrong reading of inadyn's source — see the note there.

## Why swap daemons

The TTL is the reason. Nothing was tunable in place:

| client | TTL knob? | |
|---|---|---|
| `cloudflare-dyndns` | no | hardcodes `"ttl": 1` (Auto ≈ 300s) on create, omits `ttl` from the update PUT — which Cloudflare treats as a full replacement, so it resets to Auto |
| `ddclient` | no | its `cloudflare` protocol declares only `login`, `min-interval`, `server`, `zone` |
| `inadyn` | **yes** | `ttl = SEC`, first-class in its cloudflare plugin |

inadyn's NixOS module also already defaults its timer to minutely, so the whole ask is stock configuration rather than a carried patch.

## The two provider blocks

A provider block carries one address, so dual-stack needs two. They don't collide: `plugin_register_v6` (`src/plugin.c:56`) clones the plugin as `ipv6@cloudflare.com`, and the cache file is keyed on the plugin name (`src/cache.c:119`), so the A and AAAA sides keep separate caches. `plugins/cloudflare.c` registers both.

The clone inherits the v4 plugin's `1.1.1.1` checkip while forcing its own traffic over v6, so it has to be told where to look instead. That's a `checkip-command` rather than a `checkip-server` on purpose: `get_address_backend` returns straight out of the command branch (`src/ddns.c:463`), whereas the server branch falls back to plaintext `http://ifconfig.me/ip` on failure, and `tcp_init` only *prefers* v6 rather than requiring it. Under a `checkip-server`, a v6 outage would therefore end with the v6 block holding a v4 address — and since the record type is chosen from the address, it would write that over the **A** record and cache it as the AAAA. A failing command just yields no address and no update.

The command is the same v6 DNS lookup the old Route 53 script used.

## Two other changes worth naming

**`forced-update` drops from its 30-day default to daily.** inadyn only writes on a change it observes and never re-reads the record — so without this, a record edited out of band, or one left at Auto by the previous client, is never corrected. This also restores the self-healing the Route 53 script had and cloudflare-dyndns lost. Costs one API write a day against the minutely no-ops.

**The token now reaches inadyn through an `include()` file**, because a `password` in the module's `settings` would land in the nix store. Same secret, same permissions, new `getInadynSecrets` helper to render the one-line fragment.

## Deploy

Same token at `Connor/Infrastructure/cloudflare/dynamic-dns`, unchanged permissions — the key just gets a new name and a fragment wrapper, so `cli deploy` handles it.

The AAAA gets its 60s TTL on the first run; the A record keeps its current Auto TTL until inadyn next writes it, which `forced-update` bounds at 24h. Set it to 60 in the Cloudflare dashboard if you want it immediately.

`/secrets/cloudflare-dyndns-api-token` will linger on crux — colmena doesn't remove keys dropped from the config.

Co-Authored-By: Connor Prussin <connor@prussin.net>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQuM4jtjNPGeN3LGHP15WX