### PR TITLE
[lyra] Make the DisplayLink resume restart actually run

### DIFF
--- a/config/machines/lyra/default.nix
+++ b/config/machines/lyra/default.nix
@@ -44,13 +44,57 @@ in {
       ];
     };
   };
-  systemd.services.dlm.wantedBy = ["multi-user.target"];
+  systemd.services = {
+    dlm.wantedBy = ["multi-user.target"];
 
-  # DisplayLink outputs on the dock do not survive a suspend/resume cycle:
-  # evdi/dlm does not re-establish them on wake, so the dock monitors stay
-  # dark until dlm is restarted (or the dock is replugged) by hand.  Restart
-  # dlm automatically on resume so the outputs come back.
-  powerManagement.resumeCommands = "${pkgs.systemd}/bin/systemctl restart dlm.service";
+    # DisplayLink outputs on the dock do not survive a sleep/resume cycle:
+    # evdi/dlm does not re-establish them on wake, so the monitors stay dark
+    # until dlm is restarted (or the dock is replugged) by hand.
+    #
+    # That restart used to hang off `powerManagement.resumeCommands`, where
+    # whether it ran turned on the state of the daemon it was meant to
+    # restart.  The option is not a hook of its own: every module's lines are
+    # concatenated into the `ExecStop=` of one shared `sleep-actions.service`,
+    # and nixpkgs' displaylink module contributes
+    # `echo "R" > /tmp/PmMessagesPort_in` to that block ahead of ours.  That
+    # path is DisplayLinkManager's FIFO, and opening a FIFO for writing blocks
+    # until something opens the read end, so a DisplayLinkManager that came
+    # back with that end closed blocked the write, `ExecStop=` was killed at
+    # its 90s `TimeoutStopSec`, and the restart behind it never dispatched.
+    #
+    # A unit of our own sits behind none of that.  It follows
+    # systemd.special(7)'s pattern for running something after resume -- pulled
+    # in by and ordered before `sleep.target`, with the work in `ExecStop=`,
+    # which fires when the resume leaves the unit unneeded -- and its
+    # `ExecStart=` is `true`, so nothing can fail and cancel the stop.
+    #
+    # Resist serialising this against `sleep-actions` to tidy up the overlap.
+    # Stop ordering is the reverse of start ordering, so the tempting
+    # `before = ["sleep-actions.service"]` would put this unit's `ExecStop=`
+    # last -- behind the very write that used to eat the restart.  The two
+    # running together cuts both ways: the restart can release an `echo "R"`
+    # still waiting for a reader, but it can also close the read end under one
+    # that already opened, and the `EPIPE` that follows aborts the rest of that
+    # script under the `set -e` NixOS puts in every job script (services run
+    # with `IgnoreSIGPIPE=yes` by default, so it arrives as an error rather
+    # than a signal).  Today that remainder is dhcpcd's `systemctl reload`, on
+    # a window of one 2-byte write.
+    dlm-restore = {
+      description = "Restore DisplayLink outputs after sleep";
+      wantedBy = ["sleep.target"];
+      before = ["sleep.target"];
+      unitConfig.StopWhenUnneeded = true;
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = "${pkgs.coreutils}/bin/true";
+
+        # Nothing here needs the restart to have finished, so queue it and let
+        # the resume carry on.
+        ExecStop = "${pkgs.systemd}/bin/systemctl --no-block restart dlm.service";
+      };
+    };
+  };
 
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
   hardware = {


### PR DESCRIPTION
## Why the outputs don't reliably come back

The dock's DisplayLink outputs don't survive a sleep/resume cycle, and `powerManagement.resumeCommands` already restarted `dlm` to bring them back. Whether that restart *ran* turned on the state of the daemon it was meant to restart.

The option is not a hook of its own. Every module's lines are concatenated into the `ExecStop=` of one shared [`sleep-actions.service`](https://github.com/NixOS/nixpkgs/blob/d407951447dcd00442e97087bf374aad70c04cea/nixos/modules/config/power-management.nix), and nixpkgs' [displaylink module](https://github.com/NixOS/nixpkgs/blob/d407951447dcd00442e97087bf374aad70c04cea/nixos/modules/hardware/video/displaylink.nix#L61-L63) contributes to that block **ahead of** this machine's line — nixpkgs' modules are collected first (`eval-config.nix`'s `extendModules` appends user modules) and `types.lines` keeps definition order:

```sh
echo "R" > /tmp/PmMessagesPort_in
```

That path is `DisplayLinkManager`'s FIFO, and **opening a FIFO for writing blocks until something opens the read end**:

- DLM still holding its read end open → the write returns, the restart behind it goes through, monitors come back.
- DLM back with that end closed → the write blocks, `ExecStop=` is killed at its 90s `TimeoutStopSec`, the restart never dispatches, monitors stay dark.

Not the case where DLM exited outright: `dlm.service` is `Restart=always` with `RestartSec=5`, so a new process opens the read end and releases the write.

The block is reachable a second way: `powerDownCommands` is the same unit's `ExecStart=`, and systemd runs no `ExecStop=` at all for a service whose `ExecStart=` failed — so anything failing on the way down cancels the resume half outright. (Same handshake behind nixpkgs [#281104](https://github.com/NixOS/nixpkgs/issues/281104) and [#151706](https://github.com/NixOS/nixpkgs/issues/151706).)

Shell behaviour verified directly, since the details decide the story:

| `/tmp/PmMessagesPort_in` | `echo "R" > …` |
|---|---|
| absent | **succeeds** — `>` is `O_CREAT`, creates a regular file |
| FIFO, read end closed | **blocks** on `open(O_WRONLY)` |
| FIFO, DLM holding the read end | succeeds |

Also confirmed: `[ -f ]` is false for a FIFO (so displaylink's guarded `read` branch never runs against a real FIFO), `read -t 1 < fifo` bounds the read but not the open, and a redirect failure in a `while` condition does not trip errexit. The failure is a **block**, not an error — which is why an earlier draft of this PR that reached for `set +e` was solving the wrong problem, and why it's gone.

**Honest limit:** this is a reading of the units, not something caught in a journal. The failing case should show `sleep-actions` timing out on stop.

## The fix

`dlm-restore.service`, which sits behind neither script — [systemd.special(7)'s pattern](https://github.com/systemd/systemd/blob/main/man/systemd.special.xml) for running something after resume: pulled in by and ordered before `sleep.target`, work in `ExecStop=`. `ExecStart=` is `true`, so nothing can fail and cancel the stop; `--no-block` queues the restart rather than holding the resume open.

Its `ExecStop=` now runs concurrently with `sleep-actions`' rather than after it, which cuts both ways: the restart can *release* an `echo "R"` still waiting for a reader, but it can also close the read end under one that already opened. Services run with `IgnoreSIGPIPE=yes` by default, so that arrives as `EPIPE` rather than a signal — which under the `set -e` NixOS puts in every job script still drops the rest of that script, today dhcpcd's `systemctl reload`. The window is one 2-byte write into an already-open pipe.

Note for later: don't "tidy up" that overlap with `before = ["sleep-actions.service"]`. Stop ordering is the reverse of start ordering, so that would put this unit's `ExecStop=` *last* — back behind the write that used to eat the restart. The comment in the file says so.

## Not covered

If the monitors also die on plain **DPMS blanking** (swayidle's `output * dpms off` at 10 min) with no suspend involved, this won't help — that path never touches `sleep.target`. Worth confirming separately: `swaymsg "output * dpms off"`, wait, unblank, no suspend. If the dock monitors stay dark, the follow-up is a `resumeCommand` in `config/modules/ui/swayidle/default.nix`. Left out rather than eating a `dlm` restart (and the kanshi re-apply behind it) every time you come back to the desk on a guess.

## Testing

Not run — no `nix` in this environment; CI covers `eval lyra` and `cli test format`. Wants a real suspend/resume on lyra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQuXjcKFGgC3niVpnBBTWp