### PR TITLE
[lyra] Suspend DisplayLinkManager properly instead of restarting it

### DIFF
--- a/config/machines/lyra/default.nix
+++ b/config/machines/lyra/default.nix
@@ -6,6 +6,94 @@
 }: let
   zfs = pkgs.callPackage ../../../lib/zfs.nix {};
   disk-id = "nvme-WD_BLACK_SN850X_8000GB_24456N802672";
+
+  # DisplayLinkManager takes power-management commands on one FIFO and
+  # acknowledges them on the other.  Opening a FIFO blocks until the far end is
+  # opened, and `read -t` bounds the read but not the open, so every touch of
+  # these below is wrapped in `timeout`, which can interrupt a blocked open
+  # where `read -t` cannot.  That matters because `sleep-actions.service` is
+  # `Type=oneshot`, which disables `TimeoutStartSec`: a block on the way down
+  # hangs the suspend outright rather than timing out.
+  pmIn = "/tmp/PmMessagesPort_in";
+  pmOut = "/tmp/PmMessagesPort_out";
+
+  # Set when DisplayLinkManager did not acknowledge the suspend.  `/run` is
+  # tmpfs, so this cannot survive a boot and be believed on a later resume.
+  unacknowledged = "/run/displaylink-suspend-unacknowledged";
+
+  # nixpkgs' pre-sleep block has two bugs and both bite here, so replace it
+  # rather than appending to it -- displaylink is the only contributor to
+  # `powerDownCommands` on this machine, so `mkForce` below loses nothing.
+  #
+  #   - It drains the acknowledgement FIFO with an unbounded
+  #     `while read -n 1 -t 1 _ < ${pmOut}`.  With a stale port and no
+  #     DisplayLinkManager to open the write end, that hangs the suspend
+  #     indefinitely -- nixpkgs#281104.
+  #   - It then guards upstream's acknowledgement read with `[ -f ${pmOut} ]`,
+  #     and `-f` is false for a FIFO, so the wait never runs and the machine
+  #     suspends while DisplayLinkManager is still tearing its USB side down.
+  #     Upstream's own `suspend_dlm` waits unconditionally.
+  #
+  # The second is the interesting one: it is the most likely reason
+  # DisplayLinkManager was coming back unable to drive the outputs at all.
+  # That is a hypothesis, not something observed.
+  #
+  # Worst case this costs 2 + 2 + 10s, paid when the ports exist but nothing
+  # answers on them.  Nothing removes them once DisplayLinkManager has created
+  # them and `/tmp` lives for the boot, so a stopped daemon does not make this
+  # fast -- only an absent one does.  That bound also applies on the way to
+  # shutdown, where `powerDownCommands` runs again via `post-boot.service`'s
+  # `preStop`.  Against the unbounded version that is a win where it hung --
+  # until `post-boot` hit its 90s `TimeoutStopSec` -- and a loss where the
+  # daemon is up but silent, which cost nothing before only because the `-f`
+  # guard skipped the wait entirely.
+  suspend-dlm = pkgs.writeShellScript "suspend-dlm" ''
+    ${pkgs.coreutils}/bin/timeout 2 ${pkgs.bash}/bin/bash -c \
+      'while read -n 1 -t 1 _ < ${pmOut}; do : ; done' || true
+
+    ${pkgs.coreutils}/bin/timeout 2 ${pkgs.bash}/bin/bash -c \
+      'echo "S" > ${pmIn}' || true
+
+    # Whether the acknowledgement arrives is the one signal available for
+    # whether DisplayLinkManager suspended cleanly, so hand it to the resume
+    # side rather than guessing there.
+    if ${pkgs.coreutils}/bin/timeout 10 ${pkgs.bash}/bin/bash -c \
+      'read -n 1 _ < ${pmOut}'
+    then
+      ${pkgs.coreutils}/bin/rm -f ${unacknowledged}
+    else
+      ${pkgs.coreutils}/bin/touch ${unacknowledged}
+    fi
+  '';
+
+  # The bet: a DisplayLinkManager that acknowledged the suspend should resume
+  # on the "R" nixpkgs sends and keep its evdi devices, leaving the outputs
+  # where they are and sway and kanshi with nothing to rebuild.  Restarting dlm
+  # gets the monitors back too, but only by dropping every DisplayLink output
+  # first, so spend it only where the handshake says it is needed.  If the
+  # outputs come back dark anyway, this is the assumption that was wrong, and
+  # making the restart unconditional again is the fix.
+  #
+  # Deliberately not a liveness check on ${pmIn}: `dlm.service` is
+  # `Restart=always` with `RestartSec=5`, so something holds its read end
+  # again within seconds of any crash, and such a check would answer "fine"
+  # for the case this exists to catch.
+  restore-dlm = pkgs.writeShellScript "restore-dlm" ''
+    if [ -e ${unacknowledged} ]
+    then
+      ${pkgs.systemd}/bin/systemctl --no-block restart dlm.service
+      restart=$?
+
+      # Consume it.  Every suspend rewrites this, but leaving a stale one set
+      # would make any later stop of this unit drop the outputs for nothing.
+      ${pkgs.coreutils}/bin/rm -f ${unacknowledged}
+
+      # `writeShellScript` adds no `set -e`, so without this a failed restart
+      # would exit 0 through the `rm` and leave no trace -- on the one path
+      # where the monitors depend on it having worked.
+      exit "$restart"
+    fi
+  '';
 in {
   imports = [
     ../../profiles/laptop
@@ -47,13 +135,12 @@ in {
   systemd.services = {
     dlm.wantedBy = ["multi-user.target"];
 
-    # DisplayLink outputs on the dock do not survive a sleep/resume cycle:
-    # evdi/dlm does not re-establish them on wake, so the monitors stay dark
-    # until dlm is restarted (or the dock is replugged) by hand.
+    # Runs `restore-dlm` above on resume, which restarts dlm only when the
+    # suspend handshake went unacknowledged.
     #
     # That restart used to hang off `powerManagement.resumeCommands`, where
-    # whether it ran turned on the state of the daemon it was meant to
-    # restart.  The option is not a hook of its own: every module's lines are
+    # whether it ran turned on the state of the daemon it was meant to restart.
+    # The option is not a hook of its own: every module's lines are
     # concatenated into the `ExecStop=` of one shared `sleep-actions.service`,
     # and nixpkgs' displaylink module contributes
     # `echo "R" > /tmp/PmMessagesPort_in` to that block ahead of ours.  That
@@ -71,14 +158,14 @@ in {
     # Resist serialising this against `sleep-actions` to tidy up the overlap.
     # Stop ordering is the reverse of start ordering, so the tempting
     # `before = ["sleep-actions.service"]` would put this unit's `ExecStop=`
-    # last -- behind the very write that used to eat the restart.  The two
-    # running together cuts both ways: the restart can release an `echo "R"`
-    # still waiting for a reader, but it can also close the read end under one
-    # that already opened, and the `EPIPE` that follows aborts the rest of that
-    # script under the `set -e` NixOS puts in every job script (services run
-    # with `IgnoreSIGPIPE=yes` by default, so it arrives as an error rather
-    # than a signal).  Today that remainder is dhcpcd's `systemctl reload`, on
-    # a window of one 2-byte write.
+    # last -- behind the very write that used to eat the restart.
+    #
+    # When the restart does fire and dlm is dead rather than merely silent,
+    # that write is itself blocked in `open()`, and it stays blocked until
+    # `sleep-actions` hits its 90s `TimeoutStopSec` unless the new daemon
+    # reuses the same FIFO -- taking the rest of that script, dhcpcd's
+    # `systemctl reload`, with it.  That is the cost of not waiting, and it is
+    # only paid on resumes that were already going wrong.
     dlm-restore = {
       description = "Restore DisplayLink outputs after sleep";
       wantedBy = ["sleep.target"];
@@ -88,13 +175,15 @@ in {
         Type = "oneshot";
         RemainAfterExit = true;
         ExecStart = "${pkgs.coreutils}/bin/true";
-
-        # Nothing here needs the restart to have finished, so queue it and let
-        # the resume carry on.
-        ExecStop = "${pkgs.systemd}/bin/systemctl --no-block restart dlm.service";
+        ExecStop = restore-dlm;
       };
     };
   };
+
+  # Replaces nixpkgs' block outright; see `suspend-dlm` above for why, and for
+  # why nothing is lost by forcing it.  The matching `resumeCommands` is left
+  # alone: dhcpcd contributes to that one too.
+  powerManagement.powerDownCommands = lib.mkForce "${suspend-dlm}";
 
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
   hardware = {


### PR DESCRIPTION
Follow-up to #41. Restarting `dlm` gets the monitors back by dropping every DisplayLink output first — sway evacuates the workspaces on them, kanshi re-runs its profile `exec` hooks, and the layout gets rebuilt. This tries to make the restart unnecessary.

## Why a restart was needed at all

Upstream's `suspend_dlm` sends `"S"` and then **waits** for DisplayLinkManager to acknowledge before letting the machine sleep:

```sh
#wait until suspend of DisplayLinkManager finish
read -n 1 -t 10 SUSPEND_RESULT < $COREDIR/PmMessagesPort_out
```
— [`displaylink-installer.sh`](https://github.com/renat2985/DisplayLink/blob/master/displaylink-installer.sh#L141-L151)

nixpkgs, via [Debian's packaging](https://github.com/zhsj/displaylink/blob/master/displaylink-sleep.sh), wraps that read in a guard:

```sh
if [ -f /tmp/PmMessagesPort_out ]; then
  read -n 1 -t 10 SUSPEND_RESULT < /tmp/PmMessagesPort_out
fi
```
— [`displaylink.nix`](https://github.com/NixOS/nixpkgs/blob/d407951447dcd00442e97087bf374aad70c04cea/nixos/modules/hardware/video/displaylink.nix#L47-L59)

`-f` tests for a **regular file**, and these ports are FIFOs ([the hangs in #151706](https://github.com/NixOS/nixpkgs/issues/151706) confirm it — a regular file can't block). So the guard is never true, the wait never runs, and the machine suspends while DisplayLinkManager is still tearing its USB side down. `-e` or `-p` would have been right; this came in with the block, not as a later fix.

**What's proven vs. inferred:** the `-f` bug is proven. That it's what leaves the daemon unable to drive the outputs is a hypothesis.

## What this does

The block has a **second** bug, upstream of anything an appended line could reach: it drains the ack FIFO with an unbounded `while read -n 1 -t 1 _ < …`, whose *open* blocks until a writer appears. That is the suspend hang in [nixpkgs#281104](https://github.com/NixOS/nixpkgs/issues/281104). So this replaces the block rather than appending to it — displaylink is its only contributor here, so `mkForce` loses nothing — with a version bounding every step with `timeout`, which can interrupt a blocked open where `read -t` (which bounds only the read) cannot.

Then it **gates the restart on the acknowledgement**. If the daemon suspended cleanly it should resume on the `"R"` nixpkgs already sends, keep its evdi devices, and leave the outputs alone.

Deliberately *not* a liveness check on the control FIFO, which is what the first draft did: `dlm.service` is `Restart=always`/`RestartSec=5`, so something holds its read end again within seconds of any crash, and such a check would answer "fine" for exactly the case this exists to catch — silently reverting #41.

## Testing

Logic exercised against real FIFOs (the logic, not the daemon), timings measured:

| scenario | suspend cost | resume |
|---|---|---|
| daemon acks, persistent writer on the ack port | 1s | no restart |
| daemon acks, lazy writer | 2s | no restart |
| daemon up, holds ack port, never acks | 11s | restart |
| daemon up, no writer on ack port | 12s | restart |
| stale ports, no daemon (the #281104 hang) | 14s — **finishes instead of hanging** | restart |
| no ports at all | 0s | restart |

Both generated scripts pass `bash -n` — worth checking explicitly, since CI's `eval lyra` only instantiates and would not build `writeShellScript`, so its `shellDryRun` never runs.

## Things to watch on the machine

- **Worst case adds 14s to a suspend**, paid when the ports exist but nothing answers. That also applies on the way to shutdown, where `powerDownCommands` runs again via `post-boot.service`'s `preStop` — nothing removes the FIFOs, so a merely-stopped daemon does not make it fast. Still a straight win over the unbounded version, which hung there until `post-boot` hit its 90s `TimeoutStopSec`. **If an undocked suspend is visibly slower now, the 10s ack wait is the knob.**
- **If the outputs still come back dark**, the bet on the acknowledgement was wrong: a daemon that answers `"S"` and still resumes unable to drive anything skips the restart that used to run. One-line revert — make `ExecStop` unconditional.
- `ls -l /tmp/PmMessagesPort*` would confirm the `prw-` FIFO premise the whole diagnosis rests on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQuXjcKFGgC3niVpnBBTWp