### PR TITLE
Keep the backup pool off internal mountpoints and read-only

### DIFF
--- a/config/machines/crux/backup.nix
+++ b/config/machines/crux/backup.nix
@@ -16,8 +16,22 @@
   mount = "${config.security.wrapperDir}/mount";
   umount = "${config.security.wrapperDir}/umount";
 
+  unlockBackupDisk = "unlock-${config.detachedLuksWithNixopsKeys."${config.backupDisk.diskId}".filenameBase}.service";
+
+  # Nothing is ever mounted here -- the import below is `-N` and import-tank no
+  # longer runs a pool-wide `zfs mount -a`.  The path exists to be the altroot:
+  # a prefix every mountpoint on tank-backup is rewritten under, so that even a
+  # `zfs mount -a` from somewhere this repo does not control (upstream's
+  # zfs-mount.service, a hand-run command) cannot land a received dataset on
+  # the internal path it was copied from.
+  backupAltroot = "/run/tank-backup";
+
   runBackup = pkgs.writeShellScriptBin "run-backup" ''
-    set -e
+    # pipefail because the step that matters most here is a pipeline: without
+    # it a failed `zfs send` is masked by the `zfs recv` that read its
+    # truncated output, and the script goes on to destroy the snapshot the
+    # next incremental needs as its base.
+    set -eo pipefail
 
     if [ $UID -ne 0 ]
     then
@@ -37,23 +51,217 @@
     fi
 
     echo
+    # Refuse rather than take over.  mount-external-backup imports this same
+    # pool readonly to browse it, through the same LUKS mapping name, so a run
+    # that adopted an import it did not make would export the pool and close
+    # the mapping out from under whoever was reading it.
+    if zpool list tank-backup > /dev/null 2>&1
+    then
+      echo "tank-backup is already imported;" >&2
+      echo "export it before running a backup." >&2
+      exit 1
+    fi
+
     echo -e "\e[1;37mMounting tank-backup...\e[0m"
-    systemctl start unlock-${config.detachedLuksWithNixopsKeys."${config.backupDisk.diskId}".filenameBase}.service
-    zpool import -N tank-backup
+
+    # The trap goes in before any of the state it undoes exists, rather than
+    # after: a run that stopped in the middle left the pool imported, and that
+    # was the landmine the next deploy stepped on.  Each step is gated on its
+    # own flag so cleanup only ever undoes what this run actually did.
+    UNLOCKED=no
+    IMPORTED=no
+    SNAPSHOT_TAKEN=no
+    SENT=no
+
+    cleanup() {
+      echo
+      echo -e "\e[1;37mCleaning up...\e[0m"
+
+      # A run that took today's snapshot but never got it onto the disk would
+      # leave two tank@external-backup-* snapshots behind, and the guard below
+      # turns that into a hard stop on every later run -- so a transient USB
+      # drop would wedge the backup until someone deleted a snapshot by hand.
+      # This undoes only this run's own snapshot, and only while the receive
+      # had not finished: any state this script did not create still stops the
+      # next run for a person to look at.  `SENT=no` does not mean nothing
+      # landed -- a `-R` stream commits one dataset at a time, so a drive that
+      # drops mid-send can leave today's snapshot on the leading tank-backup
+      # datasets and none on tank.  The next run's `zfs recv -F` destroys
+      # destination snapshots the sender does not have, so that resolves
+      # itself rather than needing a hand.
+      if [ "$SNAPSHOT_TAKEN" = yes ] && [ "$SENT" = no ]
+      then
+        zfs destroy -r tank@external-backup-$TODAY ||
+          echo "WARNING: tank@external-backup-$TODAY is still on tank" >&2
+      fi
+
+      if [ "$IMPORTED" = yes ] && ! zpool export tank-backup
+      then
+        # `exit` rather than falling through, for two reasons.  Falling through
+        # runs `cryptsetup close` on a device the imported pool still holds, so
+        # it fails too and its error buries this one; and a trap that returns
+        # normally hands back the status the script already had, which would
+        # report leaving the pool imported as a successful backup.
+        echo "WARNING: tank-backup is still imported." >&2
+        echo "WARNING: leaving ${unlockBackupDisk} up." >&2
+        exit 1
+      fi
+
+      if [ "$UNLOCKED" = yes ]
+      then
+        systemctl stop ${unlockBackupDisk}
+      fi
+    }
+    # The EXIT trap alone already runs cleanup when the script is signalled,
+    # but bash then reports the *previous* command's status -- so a Ctrl-C
+    # halfway through a scrub came out as exit 0, a backup that never happened
+    # reported as one that did.  These two only fix the status; cleanup still
+    # runs exactly once, from EXIT.
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+    trap cleanup EXIT
+
+    systemctl start ${unlockBackupDisk}
+    UNLOCKED=yes
+
+    # `-N` so the import mounts nothing, `-R` so that nothing else can either.
+    # The datasets on this pool are received copies of tank's and carry tank's
+    # mountpoints, /home/cprussin among them; an altroot rewrites all of them
+    # to sit under it, which is what keeps the external disk off the internal
+    # paths for the whole window the pool is imported.  `-R` also implies
+    # `cachefile=none`, so a reboot in the middle of a backup cannot bring the
+    # pool back on its own with no altroot set.
+    zpool import -N -R ${backupAltroot} tank-backup
+    IMPORTED=yes
 
     echo
     echo -e "\e[1;37mCreating backup snapshot...\e[0m"
-    export TODAY=$(date +%F)
-    export LAST_SNAP_DATE=$(zfs list -Ht snapshot -o name tank | grep external-backup | sed 's/tank@external-backup-//')
+    # Plain assignment rather than `export`: nothing here needs it in the
+    # environment, and `export VAR=$(pipeline)` reports the *builtin's* status,
+    # so pipefail would never see a failure inside the substitution.
+    TODAY=$(date +%F)
+
+    # Exactly one of these must exist.  It is both the base of the incremental
+    # below and the snapshot this run retires at the end, so neither other
+    # count has a right answer: none means there is nothing to send from and
+    # the disk needs a full replication, and more than one means an earlier run
+    # died between sending and retiring -- picking either would strand the
+    # other on tank forever and send from a base the external disk may not
+    # hold.  Both stop the run for a person to look at rather than getting
+    # worked around here.
+    #
+    # Listed and filtered in two steps rather than one pipeline: `|| true` has
+    # to be on the `grep`, so that finding nothing reaches the check below
+    # instead of pipefail killing the script with nothing said about why.  On
+    # the pipeline it would swallow a failing `zfs list` too, and answer "no
+    # snapshots" -- pointing at a full replication -- when the real problem is
+    # that tank is not there.
+    TANK_SNAPS=$(zfs list -Ht snapshot -o name tank)
+    LAST_SNAP=$(grep '^tank@external-backup-' <<< "$TANK_SNAPS" || true)
+    if [ -z "$LAST_SNAP" ] || [ "$(wc -l <<< "$LAST_SNAP")" -ne 1 ]
+    then
+      echo "Expected exactly one tank@external-backup-* snapshot, found:" >&2
+      echo "''${LAST_SNAP:-  (none)}" >&2
+      exit 1
+    fi
+
     zfs snapshot -r tank@external-backup-$TODAY
+    SNAPSHOT_TAKEN=yes
 
     echo
     echo -e "\e[1;37mSending incremental data...\e[0m"
-    zfs send -R -X tank/Cache,tank/Data/cprussin/Private,tank/Data/cprussin/Scratch,tank/Data/frigate -I tank@external-backup-$LAST_SNAP_DATE tank@external-backup-$TODAY | zfs recv -Fdu tank-backup
+    # `-u` keeps the receive from mounting anything, and `-o readonly=on`
+    # keeps anything that does get mounted -- by mount-external-backup, or by
+    # hand -- from being written to.  `readonly` is an inheritable property and
+    # `-o` on a `send -R` stream applies it to the whole received tree rather
+    # than letting tank's own `readonly=off` come across with the properties.
+    # Receives themselves are unaffected: they run below the ZPL, so the next
+    # incremental still lands.
+    zfs send -R -X tank/Cache,tank/Data/cprussin/Private,tank/Data/cprussin/Scratch,tank/Data/frigate -I "$LAST_SNAP" tank@external-backup-$TODAY | zfs recv -Fdu -o readonly=on tank-backup
+    SENT=yes
 
     echo
     echo -e "\e[1;37mScrubbing tank-backup...\e[0m"
-    zpool scrub tank-backup
+
+    # Every `zpool status` below is read by `grep`, and its output is
+    # translated, so pin the locale: sudo keeps the caller's LANG, and under
+    # one the gate at the end would reject every clean run.
+    poolStatus() {
+      LC_ALL=C zpool status tank-backup 2>&1
+    }
+
+    # Every `zpool status` from here on runs with the receive already done, so
+    # a failure leaves today's snapshot on tank beside the base this run meant
+    # to retire -- the two-snapshot state the guard above stops on.  Say what
+    # that takes to clear, rather than dying with only "Cleaning up..." on the
+    # screen.
+    snapshotsLeft() {
+      echo "$LAST_SNAP was not retired, so tank holds both it and" >&2
+      echo "tank@external-backup-$TODAY -- which the next run refuses" >&2
+      echo "to choose between.  Once tank-backup is readable, stop any" >&2
+      echo "scan still on it and destroy one of the two by hand." >&2
+      exit 1
+    }
+
+    scrubUnknown() {
+      echo "Scrub result unknown." >&2
+      snapshotsLeft
+    }
+
+    STATUS=$(poolStatus) || {
+      echo "$STATUS" >&2
+      scrubUnknown
+    }
+
+    # A scan already running has to be stopped rather than joined.  The pool
+    # resumes an interrupted scan when it is imported, so a run cut short
+    # during its scrub leaves one behind -- and `zpool scrub` on a pool already
+    # scanning is an error, which would kill the next run right here.  Joining
+    # it would not do either: it started before this run's receive, so it has
+    # already read past whatever just landed.
+    #
+    # Paused counts as running.  `zpool scrub` on a paused scan *resumes* it
+    # and returns 0 rather than erroring, so that one does not announce itself
+    # -- the loop below would wait out a scan that never read this run's data
+    # and the gate at the end would pass it.
+    #
+    # `|| true` for the race where it finishes on its own in between, which
+    # leaves nothing to stop and is not a failure.
+    if grep -qE 'scrub (in progress|paused) ' <<< "$STATUS"
+    then
+      echo "Stopping a scrub left over from an earlier run..."
+      zpool scrub -s tank-backup || true
+      STATUS=$(poolStatus) || {
+        echo "$STATUS" >&2
+        scrubUnknown
+      }
+
+      # Checked rather than assumed, because `|| true` above cannot tell the
+      # race it is there for from a stop that genuinely failed.  A scan that
+      # survived would be resumed by the `zpool scrub` below -- which returns
+      # 0 for that -- and then passed off as this run's own.
+      if grep -qE 'scrub (in progress|paused) ' <<< "$STATUS"
+      then
+        echo "A scan is still running on tank-backup after trying to" >&2
+        echo "stop it, so this run cannot tell its own scrub from that" >&2
+        echo "one." >&2
+        snapshotsLeft
+      fi
+    fi
+
+    # The scan line the pool already carries, so the gate at the end compares
+    # against it rather than trusting whatever is there when the loop ends.
+    # Its other two conditions ask whether that line describes a clean
+    # completed scrub; this one asks whether it is a new line at all, which is
+    # what keeps a result the pool was already carrying -- a clean scrub from
+    # last week among them -- from being read off as this run's own.
+    SCAN_BEFORE=$(sed -n 's/^  scan: //p' <<< "$STATUS")
+
+    zpool scrub tank-backup || {
+      echo "Could not start a scrub." >&2
+      snapshotsLeft
+    }
+
     exec 3>&1
     DRAWN=0
     clearProgress() {
@@ -65,10 +273,17 @@
     }
     while true
     do
-      NEXT=$(zpool status tank-backup 2>&1) || { clearProgress; echo "$NEXT" >&2; break; }
+      # Fatal rather than a `break`: this loop is the only thing that ever
+      # learns how the scrub went, and it used to leave $STATUS unset here and
+      # carry on to retire the base snapshot on a result nobody had.
+      NEXT=$(poolStatus) || {
+        clearProgress
+        echo "$NEXT" >&2
+        scrubUnknown
+      }
       STATUS=$NEXT
       clearProgress
-      echo "$STATUS" | grep -q 'scrub in progress' || break
+      grep -q 'scrub in progress' <<< "$STATUS" || break
       if [ -t 1 ]
       then
         WIDTH=$(tput cols <&3 2>/dev/null || echo 80)
@@ -81,11 +296,28 @@
     exec 3>&-
     echo "$STATUS"
 
+    # The scrub is the whole reason to trust what is on the external disk, and
+    # the snapshot retired below is the base the *next* incremental rests on,
+    # so nothing short of "this run's scrub finished and found nothing" may
+    # retire it.  Three conditions, because no one of them says that alone:
+    # the scan line has to have moved, or it is still the previous scrub's; it
+    # has to read as a completed clean scrub, or the run was cancelled, paused
+    # or resilvered instead; and the pool's error log has to be empty, which
+    # covers errors found outside the scan.
+    SCAN_AFTER=$(sed -n 's/^  scan: //p' <<< "$STATUS")
+    if [ "$SCAN_AFTER" = "$SCAN_BEFORE" ] ||
+      ! grep -q '^scrub repaired .* with 0 errors on ' <<< "$SCAN_AFTER" ||
+      ! grep -q '^errors: No known data errors$' <<< "$STATUS"
+    then
+      echo "tank-backup did not scrub clean." >&2
+      echo "  scan before: ''${SCAN_BEFORE:-(none)}" >&2
+      echo "  scan after:  ''${SCAN_AFTER:-(none)}" >&2
+      snapshotsLeft
+    fi
+
     echo
-    echo -e "\e[1;37mCleaning up...\e[0m"
-    zpool export tank-backup
-    systemctl stop unlock-${config.detachedLuksWithNixopsKeys."${config.backupDisk.diskId}".filenameBase}.service
-    zfs destroy -r tank@external-backup-$LAST_SNAP_DATE
+    echo -e "\e[1;37mRetiring the previous snapshot...\e[0m"
+    zfs destroy -r "$LAST_SNAP"
   '';
 in {
   services.borgbackup.jobs."rsync.net" = {

--- a/config/machines/crux/chromium-build.nix
+++ b/config/machines/crux/chromium-build.nix
@@ -39,10 +39,10 @@
   # the 500G that holds /nix, so the dataset is created with `-o quota=200G`:
   # an overrun then fails the build rather than the machine.  Moving to tank is
   # not a one-line change here -- tank is LUKS with detached keys and is
-  # imported by import-tank.service, so its datasets mount natively under
-  # `zfs mount -a` rather than through fileSystems, and run-backup's
-  # `zfs send -R` would replicate the tree to the external disk unless it is
-  # added to that command's -X list.
+  # imported by import-tank.service, so its datasets are mounted by that unit
+  # rather than through fileSystems, and run-backup's `zfs send -R` would
+  # replicate the tree to the external disk unless it is added to that
+  # command's -X list.
   pool = "tank-fast";
 
   buildRoot = "/build";

--- a/config/machines/crux/hardware.nix
+++ b/config/machines/crux/hardware.nix
@@ -39,12 +39,66 @@ in {
     after = map (drive: "unlock-${drive}.service") zfsDrives;
     bindsTo = map (drive: "unlock-${drive}.service") zfsDrives;
     script = ''
-      if [ "$(${zfsPackage}/bin/zpool get -H health tank | cut -f 3)" = "ONLINE" ]; then
+      # pipefail so that a failing `zfs list` below cannot be masked by the
+      # `sort` that reads its output.  The `zpool get` pipeline is an `if`
+      # condition, which `set -e` exempts either way.
+      set -o pipefail
+
+      # `LC_ALL=C` because the state name is translated, and under a locale
+      # that renders it as anything else this runs `zpool import` against an
+      # already-imported pool and fails the unit.
+      if [ "$(LC_ALL=C ${zfsPackage}/bin/zpool get -H health tank | cut -f 3)" = "ONLINE" ]; then
         echo "Already imported: tank"
       else
         ${zfsPackage}/bin/zpool import tank
       fi
-      ${zfsPackage}/bin/zfs mount -a
+
+      # Deliberately not `zfs mount -a`, which mounts every mountable dataset
+      # on every imported pool, not just the one this unit imports.
+      # `run-backup` holds tank-backup imported while it replicates, and the
+      # datasets it receives are copies of tank's -- mountpoints included, so
+      # /home/cprussin and friends resolve to the same paths on both pools.  A
+      # deploy restarts this unit, `zfs mount -a` then mounted the external
+      # disk over the internal one, and every write after that silently landed
+      # on the backup drive.  `run-backup` now imports under an altroot so
+      # those mountpoints cannot name an internal path at all; this loop is
+      # the other half, so nothing here can mount a pool it does not own.
+      #
+      # The filter covers what applies to this pool: skip canmount=off and
+      # canmount=noauto, skip what is already mounted, and skip legacy and
+      # mountpoint=none datasets, neither of which starts with a `/`.
+      #
+      # `zfs mount -a` additionally skips, silently, three states a per-dataset
+      # `zfs mount` treats as an error: zoned datasets, encrypted ones whose
+      # key is unavailable, and ones holding a receive-resume token.  None can
+      # arise from anything in this repo -- tank is LUKS rather than ZFS-native
+      # encryption, there are no zones, and nothing here receives into tank --
+      # so the divergence is deliberate: a hand-run `zfs recv -s` into tank
+      # that got interrupted would leave a resume token, and this unit should
+      # say so rather than skip past it.
+      #
+      # Sorted on the mountpoint rather than the dataset name because a dataset
+      # whose mountpoint is a parent path has to be mounted before anything
+      # nested under it, or it hides what is already there, and the two orders
+      # diverge wherever a mountpoint is not a mirror of the name it hangs off.
+      # `LC_ALL=C` for byte order, which is all that invariant needs; ZFS's own
+      # comparator differs in ways that do not bear on it.
+      datasets=$(${zfsPackage}/bin/zfs list -Hro name,canmount,mounted,mountpoint -t filesystem tank | LC_ALL=C sort -t "$(printf '\t')" -k 4)
+
+      # Failures are collected rather than fatal, again as `zfs mount -a` does.
+      # `/` on this machine is a tmpfs, so one dataset that cannot mount must
+      # not abort the loop and leave every later one unmounted -- writes to
+      # those paths would go to RAM.  A herestring rather than a pipe so the
+      # loop is not a subshell and `failed` survives it.
+      failed=0
+      while IFS=$'\t' read -r name canmount mounted mountpoint
+      do
+        [ "$canmount" = on ] && [ "$mounted" = no ] || continue
+        case "$mountpoint" in
+          /*) ${zfsPackage}/bin/zfs mount "$name" || failed=1 ;;
+        esac
+      done <<< "$datasets"
+      [ "$failed" -eq 0 ]
     '';
     serviceConfig = {
       RemainAfterExit = true;

--- a/config/machines/crux/private.nix
+++ b/config/machines/crux/private.nix
@@ -57,10 +57,13 @@ in {
     wantedBy = ["multi-user.target"];
 
     # `/` is a tmpfs and `/home` comes from tank, so the checkout doesn't exist
-    # until `import-tank` has run `zfs mount -a`.  `requires` propagates that
-    # unit's stop to this one; `after` is what orders this unit's stop ahead of
-    # the `zpool export` in its `preStop`, which nothing released the pool for
-    # before.
+    # until `import-tank` has mounted tank's datasets.  `requires` pulls that
+    # unit in and propagates its stop to this one; `after` is what makes this
+    # start wait for it -- `requires` alone would start the two in parallel,
+    # against a oneshot that has not finished mounting -- and orders the stop
+    # in reverse.  Only that reverse half is idle now: stopping `import-tank`
+    # takes no mounts down, and the pool stays up until the shutdown hook in
+    # hardware.nix or a hand-run `zpool export tank`.
     #
     # `network-online.target` isn't for the server, which needs no address to
     # exist before it binds -- nginx doesn't wait on it either.  It's for `nix


### PR DESCRIPTION
## The bug

Deploying to crux while `run-backup` is running mounts the external disk's
datasets over the internal ones, so subsequent writes land on the backup drive.

Two things combine:

- `run-backup` imports with `zpool import -N tank-backup` — no altroot. The
  datasets on that pool are received copies of tank's and carry tank's
  mountpoints, `/home/cprussin` among them. So they *name the exact paths the
  internal datasets are mounted at*.
- `import-tank.service` runs `zfs mount -a`, which mounts every mountable
  dataset on **every** imported pool, not just the one the unit imports. A
  deploy restarts that unit → the backup copies get mounted over the internal
  ones.

`-N` only skips mounting *at import time*; it does nothing about a later
`zfs mount -a`. And without `-R`, the import is recorded in the zpool cachefile,
so a reboot mid-backup would re-import the pool with no altroot at all.

## The fix

Three independent layers, each of which closes the hole on its own:

| | Change | Guarantee |
|---|---|---|
| 1 | `zpool import -N -R /run/tank-backup` | An altroot rewrites every mountpoint on the pool to sit under it, so nothing there can name an internal path for as long as it's imported. Also implies `cachefile=none`. |
| 2 | `zfs recv -o readonly=on` | `readonly` is inheritable, and `-o` on a `send -R` stream applies it across the received tree rather than taking tank's own `readonly=off` from the property stream. Receives run below the ZPL, so incrementals still land. |
| 3 | `import-tank` loops over tank's datasets instead of `zfs mount -a` | The unit only mounts the pool it imports. |

Layer 1 is the load-bearing one: upstream's own `zfs-mount.service` still runs a
pool-wide `zfs mount -a` at boot, so the altroot — not layer 3 — is what makes
that harmless.

Layer 3 reproduces what `-a` does, not just its filter (`canmount` off/noauto,
already mounted, `legacy`/`none` mountpoints):

- **Ordered by mountpoint, not by dataset name.** A dataset whose mountpoint is
  a parent path must mount before anything nested under it. The orders diverge
  wherever a mountpoint isn't a mirror of the name tree.
- **Failures are collected, not fatal.** `/` here is a tmpfs, so aborting the
  loop on one unmountable dataset would leave every later one unmounted with
  its writes going to RAM — the same failure class this PR is fixing.

It deliberately diverges from `-a` for three states `-a` skips silently and an
explicit `zfs mount` errors on (zoned, key unavailable, receive-resume token).
None arise from anything in this repo, and if one ever did the unit should say
so rather than skip past it.

`mount-external-backup` already did the right thing (`-o readonly=on ... -R /tank-backup`) and is unchanged.

## `run-backup` no longer carries on with an answer it doesn't have

- **`set -o pipefail`.** A failed `zfs send` was masked by the `zfs recv` that
  read its truncated output — after which the script retired the snapshot the
  next incremental needs as its base.
- **An EXIT trap**, in place before any of the state it undoes exists, with each
  step gated on its own flag so it only undoes what this run actually did. An
  interrupted run used to leave tank-backup imported — the landmine the next
  deploy stepped on. A failed export deliberately keeps the LUKS mapping open
  (`cryptsetup close` against a device the pool still holds fails too, and its
  error would bury the real one) and exits non-zero rather than reporting that
  state as a successful backup. `INT`/`TERM` get traps for the exit status
  alone: `EXIT` already ran cleanup on a signal, but reported the *previous*
  command's status, so Ctrl-C through a scrub came out as exit 0.
- **A refusal to run when `tank-backup` is already imported.**
  `mount-external-backup` imports the same pool readonly through the same LUKS
  mapping name; adopting that import would export it and close the mapping out
  from under whoever was reading it.
- **Exactly one `tank@external-backup-*` snapshot, or stop.** It's both the base
  of the incremental and what the run retires, so no other count has a right
  answer — none means the disk needs a full replication, more than one means an
  earlier run died between sending and retiring. Deliberately unrecoverable
  rather than guessed at. (The old code took whatever `grep` returned, so two of
  them expanded unquoted into extra `zfs send` arguments.) Cleanup destroys
  *this run's own* snapshot when the receive never finished, so a transient
  failure can't wedge every later run against that guard.
- **A scrub that demonstrably ran and came back clean**, before the base is
  retired. The progress loop used to `break` with `$STATUS` unset on a failed
  `zpool status`; and an `errors:` line alone says nothing about whether this
  run's scrub happened — the loop ends on any status that isn't in progress, so
  the line already on the pool would be read off as this run's result. The scan
  line must now have moved, read as a completed clean scrub, and come with an
  empty error log.
- **A leftover scan is stopped, not joined — and the stop is verified.** The
  pool resumes an interrupted scan on import, and `zpool scrub` on a scanning
  pool is an error, so the Ctrl-C case the `INT` trap was added for used to
  wedge the *next* run. Joining that scan would be unsound: it started before
  this run's receive, so it has already read past what just landed. **Paused
  counts as running**, and is the case that matters — `zpool scrub` on a paused
  scan *resumes* it and returns 0 rather than erroring, so it would otherwise
  be waited out and passed off as this run's own.
- **`LC_ALL=C` wherever zfs output is parsed.** `zpool status` and
  `zpool get health` are both gettext-wrapped and sudo keeps the caller's
  `LANG`. Under a non-C locale the scrub gate would reject every clean run, and
  `import-tank` would run `zpool import` against an already-imported pool and
  fail the unit (that second one was pre-existing).
- **A `zpool status` that fails after the receive says what it left.**
  `poolStatus()` folds stderr into stdout, so the failure text landed in
  `$STATUS` and `set -e` killed the script before printing it. Both reads now
  name the two snapshots on tank and what clearing them takes.

Two comments outside these scripts (`chromium-build.nix`, `private.nix`) still
described the `zfs mount -a` this removes; the second is the comment justifying
`requires = import-tank.service`. Both corrected — and while rebasing onto
#48, `private.nix`'s also turned out to still describe the `preStop` that the
shutdown-ramfs work took off `import-tank`, so that went too.

## Rebase note

#48 landed on the same `import-tank.service` script and conflicted: it rewired
the file from `pkgs.zfs` to `config.boot.zfs.package`, dropped
`preStop = "zpool export tank"`, and added the shutdown-ramfs teardown. The
mount loop here is kept and its `zfs`/`zpool` references rewritten to
`zfsPackage`; that commit's rename, `preStop` removal and ramfs block are
otherwise untouched.

## Verification

No NixOS host available here, so this is **not deploy-tested**; the one thing
worth confirming on the box is that `zfs recv -o readonly=on` behaves as
expected on an incremental into an existing dataset. What was checked here:

- Both rendered shell scripts pass `bash -n`; CI covers `nix flake check
  --all-systems`, lint, dead-code and alejandra formatting.
- The `import-tank` loop, against a stub `zfs list`: mounts `/var` before
  `/var/log` despite the reverse *name* order, keeps going past a dataset that
  fails to mount while still exiting non-zero, handles spaces in mountpoints,
  and skips `canmount=off`/`noauto`, already-mounted, `legacy` and `none`.
- All cleanup paths — pool already imported, happy path, failed import, failed
  send, dirty scrub, failed export — each undoing exactly the right subset, with
  the body's exit status preserved.
- The snapshot-count gate with zero, one and two matching snapshots alongside
  unrelated `zfs-auto-snap` snapshots.
- The scrub gate against six stub statuses: fresh clean scrub accepts; cancelled
  (both the reverted-scan-line and explicit forms), scrub-with-errors, clean scan
  with a dirty error log, and a resilver all reject.
- The leftover-scan block across four cases: paused leftover with a working
  stop, paused leftover with a silently-failed stop (rejects), in-progress
  leftover, and nothing running.
- Signal handling: `cleanup` runs exactly once on both `INT` and `TERM`, and the
  exit status is now 130/143 rather than 0.

`tank-fast` is mounted via `fileSystems`/systemd, not `zfs mount -a`, so scoping
the loop to `tank` doesn't affect it.

**Residual, unavoidable:** the backup datasets still carry tank's mountpoint
values, so a hand-run `zpool import tank-backup` with no `-R` would shadow the
internal paths. After this change those datasets are read-only, so it can't take
writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjXhBucyprfsTJAsHS1srs