### PR TITLE
Tear crux's pools down where it can actually work

### DIFF
--- a/config/machines/crux/hardware.nix
+++ b/config/machines/crux/hardware.nix
@@ -7,6 +7,11 @@
 }: let
   zfs = pkgs.callPackage ../../../lib/zfs.nix {};
 
+  # The userland the rest of the ZFS module is wired to, and so the one matched
+  # to the kernel module actually loaded.  `pkgs.zfs` is the same derivation
+  # only for as long as nobody sets this option.
+  zfsPackage = config.boot.zfs.package;
+
   root-disk-id = "nvme-WDS500G3X0C-00SJG0_2017A3806951";
 
   zfsDrives = [
@@ -34,18 +39,81 @@ in {
     after = map (drive: "unlock-${drive}.service") zfsDrives;
     bindsTo = map (drive: "unlock-${drive}.service") zfsDrives;
     script = ''
-      if [ "$(${pkgs.zfs}/bin/zpool get -H health tank | cut -f 3)" = "ONLINE" ]; then
+      if [ "$(${zfsPackage}/bin/zpool get -H health tank | cut -f 3)" = "ONLINE" ]; then
         echo "Already imported: tank"
       else
-        ${pkgs.zfs}/bin/zpool import tank
+        ${zfsPackage}/bin/zpool import tank
       fi
-      ${pkgs.zfs}/bin/zfs mount -a
+      ${zfsPackage}/bin/zfs mount -a
     '';
-    preStop = "${pkgs.zfs}/bin/zpool export tank";
     serviceConfig = {
       RemainAfterExit = true;
       Type = "oneshot";
     };
+  };
+
+  # The teardown deliberately does not live in an `ExecStop` on import-tank.  A
+  # service's stop job runs in the reverse of its start order, and that unit
+  # starts after `local-fs.target` -- so it stops *before* the mounts sitting on
+  # the pool come down.  The `zpool export tank` that used to be there therefore
+  # ran against a live system: it spent a minute pulling datasets out from under
+  # services systemd still believed were mounted, failed with "pool is busy"
+  # anyway, and handed the final shutdown phase a pool that was still imported
+  # over three dm-crypt mappings that then could not be closed either.
+  #
+  # A shutdown-ramfs hook is the one place this can succeed, because the copy of
+  # it that matters runs after systemd-shutdown has pivoted into the ramfs and
+  # unmounted everything.  systemd-shutdown walks that directory in both passes
+  # -- once from the real root before the pivot, once from the ramfs after it --
+  # and only the second one has anything in it, because nothing populates
+  # /etc/systemd/system-shutdown on the real root and the `mkForce` below
+  # reaches only the ramfs.  Do not assume single execution if that changes.
+  #
+  # It replaces the hook the nixpkgs ZFS module installs at this same path
+  # rather than sitting beside it: systemd runs everything in that directory in
+  # *parallel*, so a second script racing `zpool sync` for the pool namespace
+  # would be worse than superseding it -- and an export syncs on its way out.
+  # systemd caps the whole directory at 90s, so a wedge in here cannot cost more
+  # than that.
+  #
+  # The upshot is that there is now no supported way to put tank away short of a
+  # reboot: `systemctl stop import-tank` leaves the pool imported while systemd
+  # believes the unit is inactive.  Use `zpool export tank` by hand.
+  systemd.shutdownRamfs = {
+    contents."/etc/systemd/system-shutdown/zpool".source = lib.mkForce (
+      pkgs.writeShellScript "export-pools-shutdown" ''
+        # There is no udevd here -- systemd-shutdown SIGKILLed it long before
+        # this runs -- but `switch_root` carries the old /run across with a
+        # stale /run/udev/control still in it, which is what libdevmapper reads
+        # to decide whether to synchronise.  If it reads that as "udev is up",
+        # the cookie wait below has no timeout of its own and eats the whole
+        # 90s budget.
+        export DM_DISABLE_UDEV=1
+
+        ${zfsPackage}/bin/zpool export -a || true
+
+        # Anything that could not be exported -- tank-backup left imported by
+        # hand, say -- still wants its transaction group on disk, which is all
+        # the hook this replaces ever did.
+        ${zfsPackage}/bin/zpool sync || true
+
+        ${lib.concatMapStringsSep "\n" (
+          opts: "${pkgs.cryptsetup}/bin/cryptsetup close crypt-${opts.filenameBase} || true"
+        ) (builtins.attrValues config.detachedLuksWithNixopsKeys)}
+      ''
+    );
+
+    # Both of these have to be named.  make-initrd-ng follows ELF dependencies,
+    # symlinks and directory entries, but it never reads a script for store
+    # references -- so a binary a hook only mentions in its text is simply
+    # absent at shutdown, and the line fails `command not found`.
+    # `zpool` would otherwise ride along on the ZFS module's own storePaths,
+    # which the `mkForce` above does not displace, but depending on that is
+    # depending on a line of nixpkgs one below the thing being overridden.
+    storePaths = [
+      "${zfsPackage}/bin/zpool"
+      "${pkgs.cryptsetup}/bin/cryptsetup"
+    ];
   };
 
   boot = {

--- a/modules/nixos/detachedLuksWithNixopsKeys.nix
+++ b/modules/nixos/detachedLuksWithNixopsKeys.nix
@@ -93,6 +93,16 @@ in {
               "${opts.filenameBase}-header-key.service"
             ];
             script = mkUnlockScript drive opts.filenameBase;
+
+            # This closes the mapping for a deliberate `systemctl stop`, which
+            # is how `run-backup` puts the external disk away, and it is the
+            # only thing that does -- but it cannot be the shutdown story.  A
+            # stop job runs in the reverse of the start order, so at shutdown
+            # this unit stops while the pool stacked on the mapping is still
+            # imported and its datasets still mounted, and the close can only
+            # fail there with "Device is still in use".  Whoever knows what is
+            # stacked on the drive owns closing it that late, from a
+            # `systemd.shutdownRamfs` hook; see crux's hardware.nix.
             preStop = "${pkgs.cryptsetup}/bin/cryptsetup close crypt-${opts.filenameBase}";
             serviceConfig = {
               RemainAfterExit = true;


### PR DESCRIPTION
## What the journal shows

`sudo reboot` on crux does not come back. The Sep 6 attempt (`journalctl -b -1`):

```
22:17:35  frigate.service: State 'stop-sigterm' timed out. Killing.
22:17:35  Stopping import-tank.service...
22:17:42 → 22:18:36  <datasets unmounted one at a time, ~2s apart>
22:18:38  import-tank-pre-stop: cannot export 'tank': pool is busy
22:18:43  unlock-ata-…-pre-stop: Device crypt-ata-… is still in use   (×3)
22:18:43  Stopped target Local File Systems / Unmounting …
22:18:43  <last line>
```

22:18:43 is where `local-fs.target` teardown takes `/var/log` out from under journald. Everything after that — the remaining umounts, the pivot into the shutdown ramfs, the reboot itself — runs with nowhere to log. The machine goes quiet there and stays quiet until it is power cycled.

## The bug

`zpool export tank` in `import-tank`'s `preStop` could never have worked. A stop job runs in the reverse of the start order, and that unit starts after `local-fs.target`, so it stops **before** the mounts sitting on the pool come down.

So the export ran against a live system. The 22:17:42→22:18:36 block above is `zpool export` pulling datasets out from under the running machine one at a time — `/var/lib/frigate`, `/var/lib/acme`, `/root/.cache/borg`, seven of cprussin's home datasets — taking 63 seconds to reach one it could not unmount, and failing anyway. systemd's own mount units for those paths were still active while their filesystems disappeared underneath them.

The final phase was then handed a pool that was still imported, over three dm-crypt mappings that the matching `preStop` on each unlock unit could not close either — same reason, same result.

## The change

That `preStop` goes. It had never succeeded, and it was actively racing the shutdown it was part of.

The one on the unlock units **stays**: it is what a deliberate `systemctl stop` uses, and nothing else closes the mapping — `run-backup` puts the external disk away with exactly that (`config/machines/crux/backup.nix:87`). It is still useless at shutdown and still fails there; what changes is that something else now does the job afterwards.

The teardown moves to a `systemd.shutdownRamfs` hook, which runs at the one point where it can succeed: after systemd-shutdown has pivoted into the ramfs and unmounted everything. It **replaces** the hook the nixpkgs ZFS module installs at that same path rather than sitting beside it — systemd runs everything in that directory in parallel, so a second script racing `zpool sync` for the pool namespace would be worse than superseding it, and an export syncs on its way out. systemd caps the whole directory at 90s, which is what bounds everything in there: neither the export nor the closes carry a timeout of their own.

Three things the hook needs that aren't obvious, all found by review:

- **Both binaries are named in `storePaths`.** `make-initrd-ng` never reads a script for store references, so a binary a hook only mentions in its text is absent at shutdown and the line fails `command not found` — silently, behind the `|| true`. `zpool` would have ridden along on the ZFS module's own `storePaths`, one line below the `contents` this overrides; `cryptsetup` had nothing to ride on at all.
- **`DM_DISABLE_UDEV=1`**, because there is no udevd left by then and libdevmapper can't tell. It decides whether to synchronise from `/run/udev`, and `switch_root` carries the old `/run` across with a stale control socket in it. Read as "udev is up", the cookie wait has no timeout of its own and would eat the entire 90s. The removal ioctl itself is synchronous kernel work the cookie never gated, so skipping it can't leave a mapping half torn down.
- **ZFS is named once**, as `config.boot.zfs.package`, for `import-tank` and the hook alike — that's the userland matched to the loaded kernel module, and the file otherwise had two names for it with different provenance.

Not exporting during the run is what stock NixOS already does for every pool — `tank-fast` on this machine included. It has never been exported at shutdown and imports cleanly on every boot, because the hostid matches.

## Conflicts with #46

cprussin/dotfiles#46 rewrites the `script` of the same `import-tank` unit, in the same hunk. Whichever lands second needs the merge; the resolution is: take #46's script body, drop the `preStop`, and change its `pkgs.zfs` references to `zfsPackage`.

## What this does not settle

Whether this is the whole reason the reboot hangs is not proven: the phase that hangs is the one with no journal. It is proven to be wrong, and it is the only thing in that path doing something destructive.

If crux still hangs after this, the next place to look is the retained `preStop` on the unlock units. `cryptsetup close` on a busy mapping normally returns `EBUSY` fast, but it takes a libdevmapper udev cookie — if `systemd-udevd` is already stopped at that point in the transaction, that wait can stall to `TimeoutStopSec`. Worst case is ~90s across the three units in parallel, not an infinite hang, but "stalls late in shutdown" is the symptom being chased. A `dmsetup info -c -o open` guard would make the shutdown path a no-op while keeping `run-backup`'s manual stop working.

Two other things worth checking separately, neither touched here:

- **`enableSshdAtInitrd` is currently a no-op.** It sets `boot.initrd.network.enable`, but with systemd-initrd (default `true` in the pinned nixpkgs) that module's `preLVMCommands`/`extraUtilsCommands`/`postCommands` are all `mkIf (!boot.initrd.systemd.enable)`. Nothing sets `boot.initrd.systemd.network` and `networking.useDHCP` is unset, so the initrd sshd comes up with no address. There is no way into the box when it stalls, and a stall in the initrd is indistinguishable from a stall in shutdown.
- **`frigate` burns 90s on `stop-sigterm` every single shutdown** before being SIGKILLed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWmJMiqiVtYrehpTzDQFah