### PR TITLE
Point crux's borg hooks at the ZFS userland the module uses

### DIFF
--- a/config/machines/crux/backup.nix
+++ b/config/machines/crux/backup.nix
@@ -8,7 +8,11 @@
   rsyncUser = "zh2593";
   rsyncHost = "zh2593.rsync.net";
   userAtHost = "${rsyncUser}@${rsyncHost}";
-  zfs = "${pkgs.zfs}/bin/zfs";
+  # The userland the rest of the ZFS module is wired to, and so the one matched
+  # to the kernel module actually loaded, as import-tank uses -- see
+  # hardware.nix.  A store path rather than bare `zfs` because the borgbackup
+  # unit's PATH carries only borg and openssh.
+  zfs = "${config.boot.zfs.package}/bin/zfs";
   awk = "${pkgs.gawk}/bin/awk";
   sed = "${pkgs.gnused}/bin/sed";
   grep = "${pkgs.gnugrep}/bin/grep";


### PR DESCRIPTION
Follow-up to a review finding on #46 (now merged; this is rebased on top of it).

`config/machines/crux/backup.nix:11` bound `zfs = "${pkgs.zfs}/bin/zfs"` — the
last `pkgs.zfs` left in the repo. It's used by the borgbackup `preHook`/`postHook`
to `zfs snapshot`, `zfs list` and `zfs destroy` against a live `tank`, so a
userland that doesn't match the loaded kernel module would surface there,
mid-backup, rather than anywhere cheap.

#48 already made exactly this move in `config/machines/crux/hardware.nix` for
`import-tank` and the shutdown-ramfs hook, with the reasoning that `pkgs.zfs` is
the same derivation only for as long as nobody sets `boot.zfs.package`. That
holds identically here.

## Why these hooks still need a store path

The bare `zfs`/`zpool` calls in `run-backup` and `mount-external-backup` are
**not** the same bug and are deliberately left alone: nixpkgs puts
`boot.zfs.package` on `environment.systemPackages`, so PATH resolution there
already tracks the option.

The borg hooks are different. `services.borgbackup` sets the job unit's
`path = [ package pkgs.openssh ]` and inlines `preHook`/`postHook` into that
unit's script, so a bare `zfs` wouldn't resolve at all. Hence a store path —
just one now pinned to the right derivation.

## Scope

One binding. `grep -rn 'pkgs\.zfs' --include='*.nix'` now matches only prose in
comments.

No behaviour change while `boot.zfs.package` is unset, which it is — the two
evaluate to the same derivation today. This is about not depending on that.

## Verification

`eval-machines` in CI runs
`nix eval --raw '.#colmenaHive.nodes.crux.config.system.build.toplevel.drvPath'`,
which forces every module and option, so this option read is evaluated for real
rather than only linted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjXhBucyprfsTJAsHS1srs