### PR TITLE
Claude Code on crux, so the engine can be worked on where the tree is

### DIFF
--- a/config/machines/crux/claude-agent.nix
+++ b/config/machines/crux/claude-agent.nix
@@ -1,0 +1,105 @@
+# Claude Code on crux, so an agent can work on the engine where the tree is.
+#
+# Domicile carries a Chromium fork.  Everything about working on it is shaped
+# by one fact, which chromium-build.nix measured: a clean build is 4h16m and
+# 97G, and an incremental one against the warm tree here is 65s.  An agent
+# working anywhere else writes browser-process C++ from memory and finds out
+# four hours later whether it compiles; an agent here reads the real headers at
+# the pinned revision and finds out in a minute.
+#
+# That is the whole reason this exists.  It is the same argument domicile-ci.nix
+# makes for the CI runner, one step further: CI proves a change compiles, and
+# this is for *writing* the change in the first place.
+#
+#
+# WHY THERE IS NO SERVICE HERE.
+#
+# `claude --remote-control` starts an *interactive* session -- the flag's own
+# help says so -- so there is nothing to run under systemd.  A unit with no
+# terminal would either fail or sit there being useless, and a unit that
+# pretended otherwise would be a lie in a file people trust.
+#
+# tmux is what makes an interactive session outlive an ssh disconnect, and the
+# server profile already brings it in (config/modules/ui/session).  So the whole
+# of this module is: put the CLI on the machine, and write down the two things
+# that are easy to get wrong.
+#
+# `claude-agent` starts or reattaches to it.  Reattaching matters more than it
+# sounds: a second `--remote-control` session is a second agent on the same
+# build tree, which is the collision below.
+#
+#
+# IT SHARES /build WITH THE CI RUNNER, AND THAT IS THE SHARP EDGE.
+#
+# domicile-ci.nix says it plainly for its own case: two concurrent `autoninja`
+# runs against one out/ directory corrupt each other.  The runner uses
+# out/Domicile, because that is what packages/domicile-engine/scripts/build.sh
+# defaults to.  So an agent that builds must not use out/Domicile, and that is
+# what DOMICILE_AGENT_OUT is for -- build.sh takes OUT from the environment.
+#
+# The cost is disk.  A second out/ is not free against the 200G quota the
+# Chromium tree already takes 97G of, and it is the reason this is a documented
+# variable rather than a second tree.
+#
+# Worse than a corrupt build, and worth stating because it happened: a failed
+# `gn gen` writes args.gn before the assert that failed it, and ninja re-runs
+# gn on every build.  One bad `gn gen` in a shared out/ leaves *every* branch's
+# CI failing with `rebuild manifest failed`, which reads as a code error and is
+# not one.
+#
+#
+# IT RUNS AS THE PRIMARY USER, WHICH IS MORE THAN THE RUNNER ASKS FOR.
+#
+# domicile-ci.nix already accepts that trade for CI, and its compensating
+# control is that fork pull requests cannot run on it -- a workflow file is
+# reviewed before it executes.  An interactive agent has no such gate: whoever
+# is driving it can run anything this user can, on a machine that also serves
+# dns, matrix, home-assistant and the backups.
+#
+# There is no technical control here for that, and pretending otherwise would
+# be worse than saying so.  The control is that a person starts it deliberately
+# and closes it when the work is done.  It is not enabled at boot and nothing
+# starts it automatically, which is the only part this file can enforce.
+{
+  config,
+  pkgs,
+  ...
+}: let
+  # Where an agent checks Domicile out.  Beside the Chromium tree rather than
+  # in the primary user's home, for the reason domicile-ci.nix puts its own
+  # workspace here: the NVMe dataset is where the build artifacts belong, and
+  # cargo and bun scratch is build artifacts.
+  #
+  # Not shared with /build/github-runner, which the runner's ExecStartPre
+  # deletes the contents of on every start -- an agent's uncommitted work would
+  # go with it.
+  workDir = "/build/claude-agent";
+
+  claude-agent = pkgs.writeShellScriptBin "claude-agent" ''
+    set -eu
+
+    # Reattach rather than start a second one.  Two agents on one build tree is
+    # the collision this module's header is about, and `new-session -A` is the
+    # cheapest way to make the mistake impossible rather than documented.
+    exec ${pkgs.tmux}/bin/tmux new-session -A -s claude-agent \
+      "cd ${workDir} && exec ${pkgs.claude-code}/bin/claude --remote-control crux"
+  '';
+in {
+  environment = {
+    # `environment.systemPackages`, deliberately, and not the primary user's
+    # `home.packages`: config/modules/ui/session sets that with `lib.mkForce`,
+    # so a second module adding to it either loses or clobbers depending on
+    # which the module system sees last.
+    systemPackages = [pkgs.claude-code claude-agent];
+
+    # What build.sh should be told, so an agent's build never lands in the
+    # runner's out/Domicile.  Exported for every login rather than left in a
+    # README, because the failure it prevents is silent for the *other* user of
+    # the tree -- CI goes red on branches nobody touched.
+    variables.DOMICILE_AGENT_OUT = "out/Agent";
+  };
+
+  systemd.tmpfiles.rules = [
+    "d ${workDir} 0755 ${config.primary-user.name} users -"
+  ];
+}

--- a/config/machines/crux/default.nix
+++ b/config/machines/crux/default.nix
@@ -7,6 +7,7 @@
     ./backup.nix
     ./chromium-build.nix
     ./circinus.nix
+    ./claude-agent.nix
     ./dns.nix
     ./domicile-ci.nix
     ./dynamic-dns.nix


### PR DESCRIPTION
Adds `config/machines/crux/claude-agent.nix`: the `claude-code` CLI, and a `claude-agent` wrapper that starts or reattaches to a tmux session running `claude --remote-control crux` in `/build/claude-agent`.

## Why

`chromium-build.nix` already measured the number this turns on: a clean Chromium build is **4h16m and 97G**, an incremental one against the warm tree here is **65s**.

An agent working anywhere else writes browser-process C++ from memory, can't read the headers at the pinned revision, and finds out four hours later whether it compiles. On crux it reads the real source and finds out in a minute. Same argument `domicile-ci.nix` makes for the runner, one step earlier — CI proves a change compiles; this is for *writing* it.

The immediate work is a `domicile://` scheme replacing the loopback HTTP port the shell is served over. That port is the desktop's control plane — its WebSocket is a byte pipe to the compositor, whose protocol carries `Spawn { command }` — and until an origin check landed today, any website could scan for it and drive the desktop. Design is in domicile's `docs/architecture/ENGINE-FORK.md`; what it needs is a checkout, which is this.

## No service, because `--remote-control` is interactive

The flag's own help says so, so there's nothing to run under systemd — a unit with no terminal would either fail or sit there being useless. tmux makes an interactive session survive a disconnect, and the server profile already brings it in.

So the module is: the CLI, a wrapper that starts or **reattaches** to one session, and the hazards written down. Reattaching matters more than it sounds — a second `--remote-control` session is a second agent on the same build tree.

## The hazards, both about sharing `/build` with the CI runner

- **Two concurrent `autoninja` runs against one `out/` corrupt each other** — `domicile-ci.nix` already says this for its own case. The runner uses `out/Domicile` because that's `build.sh`'s default, so `DOMICILE_AGENT_OUT=out/Agent` points an agent's builds elsewhere. Costs disk against the 200G quota, which is why it's a documented variable rather than a second tree.
- **Worse, and observed today:** a failed `gn gen` writes `args.gn` *before* the assert that failed it, and ninja re-runs gn every build. One bad `gn gen` in a shared `out/` left every branch's CI failing with `rebuild manifest failed` — which reads as a code error and isn't one. It cost a repair commit.

## And one hazard that isn't technical

This runs as the primary user, like the runner, but **without the runner's compensating control**. `domicile-ci.nix` is explicit that its trade is only safe because fork PRs can't run on it — a workflow file is reviewed before it executes. An interactive agent is not, and this machine also serves dns, matrix, home-assistant and the backups.

There's no technical control for that here, and claiming one would be worse than saying so. What the file *can* enforce is that nothing starts it automatically, and nothing does.

## Notes

`environment.systemPackages` rather than the primary user's `home.packages`: `config/modules/ui/session` sets that with `lib.mkForce`, so a second module adding to it either loses or clobbers depending on evaluation order.

**Not evaluated.** Written from a container that can't fetch this flake's nixpkgs, so `pkgs.claude-code` is confirmed present in nixpkgs (2.1.260) but not against this repo's pin, and the module hasn't been built. `alejandra`, `statix` and `deadnix` are clean. The deploy is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCE9e23jLLQ3XbZyfPdLo6

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCE9e23jLLQ3XbZyfPdLo6)_