### PR TITLE
Don't nest a tmux inside the one you already connected with

### DIFF
--- a/config/machines/crux/claude-agent.nix
+++ b/config/machines/crux/claude-agent.nix
@@ -25,13 +25,24 @@
 # for no gain.  So `claude-agent` is a `cd` and an `exec`, and the session it
 # starts belongs to whatever the caller is already running under.
 #
-# THE ONE THING THAT COSTS.  It used to be `tmux new-session -A`, which
-# reattached rather than starting a second agent, and a second
+# WHAT TOOK OVER FROM `new-session -A`.  Reattaching had a second job besides
+# convenience: it made a second agent impossible, and a second
 # `--remote-control` session is a second agent on the same build tree -- the
-# collision the next section is about.  That is documented now rather than
-# enforced: run `claude-agent` twice and you get two.  Enforcing it without a
-# multiplexer would take a lock file, which is machinery this module has not
-# been asked for.
+# collision the next section is about.  Without a multiplexer that has to be a
+# lock, so it is one.
+#
+# `flock -n` takes an exclusive lock and fails immediately rather than waiting,
+# so the second `claude-agent` refuses and says where the first one is instead
+# of quietly becoming a second writer.  The lock lives on an open file
+# descriptor, and descriptors survive `exec` -- so the agent process holds it
+# for its whole life and the kernel drops it when that process dies.  There is
+# no stale lock to clean up after a crash, which is the failure mode a pid file
+# would have had.
+#
+# IT GUARDS AGENT AGAINST AGENT, AND NOTHING ELSE.  The CI runner does not take
+# this lock and cannot be made to from here, so it is `DOMICILE_AGENT_OUT` that
+# keeps the two apart -- see below.  Saying which half a guard covers is worth
+# more than the guard.
 #
 #
 # IT SHARES /build WITH THE CI RUNNER, AND THAT IS THE SHARP EDGE.
@@ -80,15 +91,30 @@
   # go with it.
   workDir = "/build/claude-agent";
 
-  # `cd` and `exec`, and that is deliberately all of it.  What this buys over
-  # typing the command is the working directory and the session name, both of
-  # which are easy to get wrong and neither of which is worth a wrapper that
-  # does anything else.
+  # The lock, in the per-user runtime directory: a tmpfs the system clears
+  # between logins, so nothing accumulates.  `/tmp` only as a fallback, since
+  # XDG_RUNTIME_DIR is not guaranteed to be set over ssh, and named by uid
+  # there because /tmp is shared and a fixed name in it is another user's to
+  # take.
   #
-  # `exec` so the shell is replaced rather than left waiting: a signal reaches
-  # the agent, and the exit status is the agent's.
+  # `exec` so the shell is replaced rather than left waiting on a child: a
+  # signal reaches the agent, and the exit status is the agent's.
   claude-agent = pkgs.writeShellScriptBin "claude-agent" ''
     set -eu
+
+    lock="''${XDG_RUNTIME_DIR:-/tmp}/claude-agent.$(${pkgs.coreutils}/bin/id -u).lock"
+    # Held on the descriptor, not by the file existing, so this survives the
+    # `exec` below and is released by the kernel when the agent exits --
+    # crash included.
+    exec 9>"$lock"
+    ${pkgs.util-linux}/bin/flock -n 9 || {
+      echo "claude-agent: one is already running on this machine." >&2
+      echo "  A second would be a second agent on ${workDir} and on the" >&2
+      echo "  Chromium tree beside it, which is the collision this refuses." >&2
+      echo "  Attach to the session you already have, or stop it first." >&2
+      exit 1
+    }
+
     cd "${workDir}"
     exec ${pkgs.claude-code}/bin/claude --remote-control crux
   '';

--- a/config/machines/crux/claude-agent.nix
+++ b/config/machines/crux/claude-agent.nix
@@ -12,21 +12,26 @@
 # this is for *writing* the change in the first place.
 #
 #
-# WHY THERE IS NO SERVICE HERE.
+# WHY THERE IS NO SERVICE HERE, AND NO TERMINAL MULTIPLEXER EITHER.
 #
 # `claude --remote-control` starts an *interactive* session -- the flag's own
 # help says so -- so there is nothing to run under systemd.  A unit with no
 # terminal would either fail or sit there being useless, and a unit that
 # pretended otherwise would be a lie in a file people trust.
 #
-# tmux is what makes an interactive session outlive an ssh disconnect, and the
-# server profile already brings it in (config/modules/ui/session).  So the whole
-# of this module is: put the CLI on the machine, and write down the two things
-# that are easy to get wrong.
+# Something has to make that session outlive an ssh disconnect, but it is not
+# this module: whoever connects to this machine already lands in tmux, and a
+# wrapper that started its own would nest one inside it -- two prefix keys deep
+# for no gain.  So `claude-agent` is a `cd` and an `exec`, and the session it
+# starts belongs to whatever the caller is already running under.
 #
-# `claude-agent` starts or reattaches to it.  Reattaching matters more than it
-# sounds: a second `--remote-control` session is a second agent on the same
-# build tree, which is the collision below.
+# THE ONE THING THAT COSTS.  It used to be `tmux new-session -A`, which
+# reattached rather than starting a second agent, and a second
+# `--remote-control` session is a second agent on the same build tree -- the
+# collision the next section is about.  That is documented now rather than
+# enforced: run `claude-agent` twice and you get two.  Enforcing it without a
+# multiplexer would take a lock file, which is machinery this module has not
+# been asked for.
 #
 #
 # IT SHARES /build WITH THE CI RUNNER, AND THAT IS THE SHARP EDGE.
@@ -75,14 +80,17 @@
   # go with it.
   workDir = "/build/claude-agent";
 
+  # `cd` and `exec`, and that is deliberately all of it.  What this buys over
+  # typing the command is the working directory and the session name, both of
+  # which are easy to get wrong and neither of which is worth a wrapper that
+  # does anything else.
+  #
+  # `exec` so the shell is replaced rather than left waiting: a signal reaches
+  # the agent, and the exit status is the agent's.
   claude-agent = pkgs.writeShellScriptBin "claude-agent" ''
     set -eu
-
-    # Reattach rather than start a second one.  Two agents on one build tree is
-    # the collision this module's header is about, and `new-session -A` is the
-    # cheapest way to make the mistake impossible rather than documented.
-    exec ${pkgs.tmux}/bin/tmux new-session -A -s claude-agent \
-      "cd ${workDir} && exec ${pkgs.claude-code}/bin/claude --remote-control crux"
+    cd "${workDir}"
+    exec ${pkgs.claude-code}/bin/claude --remote-control crux
   '';
 in {
   environment = {


### PR DESCRIPTION
`claude-agent` ran `tmux new-session -A -s claude-agent`. Connecting to crux already lands you in tmux, so that started a second one inside the first — two prefix keys deep, for a session the outer one was already keeping alive.

The wrapper is now:

```sh
set -eu
lock="${XDG_RUNTIME_DIR:-/tmp}/claude-agent.$(id -u).lock"
exec 9>"$lock"
flock -n 9 || { …refuse and say where the first one is…; }
cd "/build/claude-agent"
exec …/claude --remote-control crux
```

`exec` so the shell is replaced rather than left waiting on a child: a signal reaches the agent, and the exit status is the agent's.

## The lock, because reattaching was doing real work

`new-session -A` had a second job besides convenience: it made a second agent **impossible**. A second `--remote-control` session is a second agent on the same build tree — the `out/` collision the module's header is about, where two concurrent `autoninja` runs corrupt each other. Dropping tmux dropped that guard, so it comes back as a lock.

`flock -n` takes an exclusive lock and **fails immediately** rather than waiting, so the second `claude-agent` refuses and says where the first one is instead of quietly becoming a second writer.

The lock is held on an open **file descriptor**, and descriptors survive `exec` — so the agent process holds it for its whole life and the kernel drops it when that process dies. There is no stale lock to clean up after a crash, which is the failure mode a pid file would have had.

Verified against real `flock`, both halves:

- a second invocation refuses while the first has already `exec`ed into something else (proving the lock survives `exec`), and
- the lock is reacquirable once the holder exits.

**It guards agent against agent and nothing else.** The CI runner does not take this lock and cannot be made to from here; `DOMICILE_AGENT_OUT=out/Agent` is what keeps those two apart. Written down in the module, because a guard whose scope is unstated reads as covering more than it does.

In `XDG_RUNTIME_DIR`, a per-user tmpfs the system clears between logins. `/tmp` only as a fallback, since `XDG_RUNTIME_DIR` is not guaranteed set over ssh, and named by uid there because `/tmp` is shared and a fixed name in it is another user's to take.

## Notes

The "no service" reasoning is unchanged and still holds — `claude --remote-control` starts an *interactive* session (verified against the CLI's own `--help`), so there is nothing to run under systemd, and nothing starts this automatically.

**Not evaluated as Nix.** `alejandra`, `statix` and `deadnix` are not in this container this time; CI's `eval crux` is the check. The shell logic above was run for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCE9e23jLLQ3XbZyfPdLo6