### PR TITLE
Start the agent with `claude rc`

### DIFF
--- a/config/machines/crux/claude-agent.nix
+++ b/config/machines/crux/claude-agent.nix
@@ -14,10 +14,18 @@
 #
 # WHY THERE IS NO SERVICE HERE, AND NO TERMINAL MULTIPLEXER EITHER.
 #
-# `claude --remote-control` starts an *interactive* session -- the flag's own
-# help says so -- so there is nothing to run under systemd.  A unit with no
-# terminal would either fail or sit there being useless, and a unit that
-# pretended otherwise would be a lie in a file people trust.
+# `claude rc` starts an *interactive* Remote Control session, so there is
+# nothing to run under systemd.  A unit with no terminal would either fail or
+# sit there being useless, and a unit that pretended otherwise would be a lie
+# in a file people trust.
+#
+# `rc` rather than the `--remote-control crux` this used to pass: it is the
+# subcommand for the same thing, and it takes the session name from the
+# hostname (see `--remote-control-session-name-prefix`, whose default is the
+# hostname), which on this machine is the name that was being passed by hand.
+# Worth a line because `rc` does not appear in `claude --help` -- it resolves,
+# and an unknown subcommand there says so, but nobody will find it by reading
+# the help.
 #
 # Something has to make that session outlive an ssh disconnect, but it is not
 # this module: whoever connects to this machine already lands in tmux, and a
@@ -27,7 +35,7 @@
 #
 # WHAT TOOK OVER FROM `new-session -A`.  Reattaching had a second job besides
 # convenience: it made a second agent impossible, and a second
-# `--remote-control` session is a second agent on the same build tree -- the
+# Remote Control session is a second agent on the same build tree -- the
 # collision the next section is about.  Without a multiplexer that has to be a
 # lock, so it is one.
 #
@@ -116,7 +124,7 @@
     }
 
     cd "${workDir}"
-    exec ${pkgs.claude-code}/bin/claude --remote-control crux
+    exec ${pkgs.claude-code}/bin/claude rc
   '';
 in {
   environment = {


### PR DESCRIPTION
`rc` is the subcommand for the same thing `--remote-control` did, and it takes the session name from the hostname — `--remote-control-session-name-prefix` defaults to it — which on this machine is exactly the `crux` that was being passed by hand.

```sh
-    exec …/claude --remote-control crux
+    exec …/claude rc
```

## One line earned its place in the file

`rc` **does not appear in `claude --help`**. It resolves — an unknown subcommand says so, and this one gets as far as complaining about where it is being run — but nobody would find it by reading the help, and a future reader diffing this against `--help` would take it for a typo. So the module says that rather than leaving it to be rediscovered.

The rest is unchanged and still holds: it is an interactive session, so there is nothing to run under systemd; the `flock` still refuses a second agent on the same build tree; nothing starts it automatically.

**Not evaluated as Nix** — `alejandra`, `statix` and `deadnix` are not in this container; CI's `eval crux` is the check. The subcommand itself was verified against the `claude` CLI available here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCE9e23jLLQ3XbZyfPdLo6

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCE9e23jLLQ3XbZyfPdLo6)_