### PR TITLE
Wait for tank-backup to be released before exporting it

### DIFF
--- a/config/modules/data/backup/default.nix
+++ b/config/modules/data/backup/default.nix
@@ -58,7 +58,50 @@
 
     sudo umount /home/cprussin/.bak
     rmdir /home/cprussin/.bak
-    sudo zpool export tank-backup
+
+    # `umount` only detaches the mount from the namespace and returns.  bindfs,
+    # the FUSE daemon serving it, is asked to shut down asynchronously and keeps
+    # /tank-backup as its working directory until it actually exits -- a live
+    # cwd on the dataset is exactly what keeps it from being unmounted.
+    # Exporting into that window is what failed with "pool is busy", so wait
+    # the daemon out rather than racing it.
+    EXPORTED=no
+    WAITING=no
+    for _ in {1..30}
+    do
+      if ERROR=$(sudo zpool export tank-backup 2>&1)
+      then
+        EXPORTED=yes
+        break
+      elif [ "$WAITING" = no ]
+      then
+        WAITING=yes
+        echo -n "Waiting for the pool to be released..."
+      fi
+      echo -n '.'
+      sleep 0.5
+    done
+
+    if [ "$WAITING" = yes ]
+    then
+      echo
+    fi
+
+    # Say what is left up rather than suggesting a re-run: the umount above has
+    # already happened, so running this again just dies on the missing
+    # mountpoint.  The pool matters more than the mapping -- run-backup
+    # refuses to run at all while tank-backup is imported.
+    if [ "$EXPORTED" = no ]
+    then
+      echo "$ERROR" >&2
+      echo "WARNING: tank-backup is still imported." >&2
+      echo "WARNING: leaving crypt-${config.backupDisk.filenameBase} open." >&2
+      echo "Once the pool is free, finish with:" >&2
+      echo "  sudo zpool export tank-backup &&" >&2
+      echo "    sudo cryptsetup close crypt-${config.backupDisk.filenameBase}" >&2
+      exit 1
+    fi
+
     sudo cryptsetup close crypt-${config.backupDisk.filenameBase}
   '';
 in {


### PR DESCRIPTION
## Problem

`umount-external-backup` fails with `cannot export 'tank-backup': pool is busy` on essentially every run, while running `sudo zpool export tank-backup` by hand a moment later always succeeds.

## Cause

`umount` only detaches the mount from the namespace and returns. bindfs — the FUSE daemon serving `/home/cprussin/.bak` out of `/tank-backup` — `fchdir`s into its source at startup and keeps `/tank-backup` as its working directory until it actually exits. A live cwd on the dataset is exactly what keeps it from being unmounted, so ZFS returns `EBUSY`.

The `zpool export` on the very next line lands inside that window.

## Fix

Retry the export for up to 15s rather than racing the daemon, printing the same progress dots `mount-external-backup` already uses while it waits for the drive. Silent when it succeeds first try, which is the common case once the daemon is gone.

On giving up, print what ZFS actually said and name both things left up, rather than suggesting a re-run — the `umount` has already happened, so running it again just dies on the missing mountpoint. The still-imported pool is the half that matters: `run-backup` refuses to run at all while `tank-backup` is imported (`config/machines/crux/backup.nix:62`), whereas a leftover LUKS mapping is adopted cleanly by the unlock service. `cryptsetup close` is skipped on that path deliberately — it would fail anyway under the imported pool.

## Testing

No nix in this environment, so the change is unbuilt here — CI evaluates it. Verified against the rendered script with a stubbed `zpool`:

- succeeds first try → silent, closes the mapper, `rc=0`
- busy for three attempts → dots, then succeeds, closes the mapper, `rc=0`
- always busy → ~16s, dots, real ZFS error plus both warnings and the recovery command, no `cryptsetup close`, `rc=1`
- always busy on a minimal PATH → same (the loop uses brace expansion, not `seq`)

Also checked the rendered shell parses (`bash -n`) and that no stray `${` leaks into Nix interpolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C2rNkroXgiW9aHC7HfvTr