### PR TITLE
[sunshine] cap the cast bitrate at 40 Mbps

### DIFF
--- a/config/modules/ui/sunshine/default.nix
+++ b/config/modules/ui/sunshine/default.nix
@@ -52,6 +52,13 @@ in {
       # requests; it does not change what Sunshine binds, so the port stays
       # closed below too.
       origin_web_ui_allowed = "pc";
+
+      # Kbps, and a ceiling rather than a target: 0 -- the default -- encodes
+      # at whatever Moonlight asks for, and Moonlight's 4K presets ask for more
+      # than the Wi-Fi hop to the TV carries, which arrives as artifacts and
+      # stutter.  Capping here rather than in Moonlight keeps it with the rest
+      # of the cast config, and covers any client that pairs later.
+      max_bitrate = 40000;
     };
   };
 

--- a/docs/casting-design.org
+++ b/docs/casting-design.org
@@ -84,6 +84,21 @@ Sunshine's log for the encoder it picked: the software fallback cannot hold
 drops the mode while keeping the scale -- a quarter-size desktop the client
 upscales, which looks exactly like the bug the mode is here to fix.
 
+** Why the bitrate is capped on the host
+
+Moonlight's 4K presets ask for more than the Wi-Fi hop to the TV carries, and
+Sunshine encodes whatever is asked for: the excess shows up as artifacts and
+stutter, not as a dropped resolution.  ~max_bitrate~ is a ceiling, so the cap
+is inert whenever the client asks for less.
+
+On the host rather than in Moonlight because it lives with the rest of the cast
+config and applies to any client that pairs later; the TV's Moonlight settings
+are not in this repo and cannot be reviewed from it.
+
+40 Mbps is a starting point, not a measurement.  It is the one number to move
+if the stream misbehaves -- before touching the mode, which the placement
+arithmetic above depends on.
+
 ** Why cast places workspace 10, not kanshi
 
 kanshi matches a profile only when its output count equals the number of

--- a/docs/casting.org
+++ b/docs/casting.org
@@ -38,9 +38,13 @@ when it breaks.
   Sunshine streams that.
 - It is 3840x2160 at scale 2 -- Sunshine captures the output's *mode*, so that
   is the ceiling on the stream; what actually goes out is whatever Moonlight
-  asks for.  Set Moonlight to 4K and HEVC, with the bitrate raised to match.
-  If it stutters, drop Moonlight back to 1080p: the capture stays 4K and
-  downscales, so nothing else has to change.
+  asks for, up to ~max_bitrate~.  Set Moonlight to 4K and HEVC, with the
+  bitrate raised to match.  If it stutters, drop Moonlight back to 1080p: the
+  capture stays 4K and downscales, so nothing else has to change.
+- The stream is capped at 40 Mbps in ~max_bitrate~, below what Moonlight's 4K
+  presets ask for.  Artifacts and stutter mean it is still too high for the
+  link; a sharper picture that holds means it can go up.  Either way it is
+  ~max_bitrate~ in [[../config/modules/ui/sunshine/default.nix][config/modules/ui/sunshine]], not a Moonlight setting.
 - It sits above your column, so the pointer reaches it off the top edge --
   crossing any monitor stacked above the laptop on the way.
 - Workspace 10 moves onto it: ~Mod+asterisk~ focuses the TV,


### PR DESCRIPTION
Casting showed artifacts and stutter on the TV.

Sunshine's `max_bitrate` defaults to `0`, meaning it encodes at whatever Moonlight asks for — and Moonlight's 4K presets ask for more than the Wi-Fi hop to the TV carries. The excess surfaces as artifacts and stutter rather than as a dropped resolution.

- `max_bitrate = 40000` (Kbps) in `config/modules/ui/sunshine`. It is a ceiling, so it is inert whenever the client asks for less.
- On the host rather than in Moonlight: it lives with the rest of the cast config and covers any client that pairs later.
- Docs updated — `casting.org` says which knob to turn and which way, `casting-design.org` says why it is host-side.

40 Mbps is a starting point, not a measurement. Still artifacting means lower; clean and sharp means it can go up.

`max_bitrate` is present in the pinned Sunshine (`v2026.516.143833`, `src/config.cpp`), and the module's `settings` is a freeform `keyValue` submodule, so an int serializes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wg8WMZniRaqv6ZBZsehKZk


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wg8WMZniRaqv6ZBZsehKZk)_