### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: cachix/install-nix-action@v31
       - name: Build the dev shell
         run: nix develop --print-build-logs --command true
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: cachix/install-nix-action@v31
       - name: nix flake show
         run: nix flake show --all-systems
@@ -70,7 +70,7 @@ jobs:
           - iot-devices
           - read-dmarc
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: cachix/install-nix-action@v31
       - name: Build ${{ matrix.package }}
         run: nix build --print-build-logs ".#${{ matrix.package }}"
@@ -91,7 +91,7 @@ jobs:
           - lyra
           - crux
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: cachix/install-nix-action@v31
       - name: Instantiate ${{ matrix.machine }}
         # Pure, like `colmena apply`, which evaluates flake hives with
@@ -128,7 +128,7 @@ jobs:
           - powerpanel
           - sudo
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: cachix/install-nix-action@v31
       - name: Build ${{ matrix.package }}
         run: |
@@ -150,7 +150,7 @@ jobs:
           - installer
           - gpg-offline
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: cachix/install-nix-action@v31
       - name: Build the ${{ matrix.iso }} iso
         run: nix build --print-build-logs ".#${{ matrix.iso }}"


### PR DESCRIPTION
## Upgraded
- `actions/checkout@v5` -> `actions/checkout@v7` in `.github/workflows/ci.yml` (latest major; `v7.0.1` released 2026-07-20, >7 days old — satisfies the minimum release age policy)

## Skipped
- `cachix/install-nix-action@v31` — already the latest major tag (patch `v31.11.1` released 2026-08-13); no newer major exists, so nothing to bump
- `flake.lock` — `nix` is not available in this sandbox, so `nix flake update` could not be run. Inputs (`nixpkgs`, `nixpkgs-unstable`, `home-manager`, `colmena`, `flake-utils`, `dircolors-solarized`, `fzf-pass`, `gpg-key`, `mkCli`, `gmail-new-mail-counter`, `nixos-hardware`, `notify-send`, `zoom-frm`) need a `nix flake update` run in an environment with `nix` available.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bFLpqdKXRuKWSDxfPDbLy

---
_Generated by [Claude Code](https://claude.ai/code/session_011bFLpqdKXRuKWSDxfPDbLy)_